### PR TITLE
Playtest ancient secrets (#1181)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "tabWidth": 4,
+    "singleQuote": true,
+    "trailingComma": "none",
+    "printWidth": 120
+}

--- a/package.json
+++ b/package.json
@@ -126,5 +126,8 @@
     "webpack-dev-middleware": "^1.12.0",
     "webpack-dev-server": "^2.9.0",
     "webpack-hot-middleware": "^2.19.1"
+  },
+  "volta": {
+    "node": "12.18.3"
   }
 }

--- a/server/game/Constants.ts
+++ b/server/game/Constants.ts
@@ -37,6 +37,8 @@ export enum EffectNames {
     AddFaction = 'addFaction',
     AddKeyword = 'addKeyword',
     AddTrait = 'addTrait',
+    LoseTrait = 'loseTrait',
+    AttachmentCardCondition = 'attachmentCardCondition',
     AttachmentFactionRestriction = 'attachmentFactionRestriction',
     AttachmentLimit = 'attachmentLimit',
     AttachmentMyControlOnly = 'attachmentMyControlOnly',
@@ -72,6 +74,7 @@ export enum EffectNames {
     HonorCostToDeclare = 'honorCostToDeclare',
     FateCostToRingToDeclareConflictAgainst = 'fateCostToRingToDeclareConflictAgainst',
     FateCostToTarget = 'fateCostToTarget',
+    PlayerFateCostToTargetCard = 'playerFateCostToTargetCard',
     GainAbility = 'gainAbility',
     GainAllAbilities = 'gainAllAbilities',
     GainAllAbilitiesDynamic = 'gainAllAbilitiesDynamic',
@@ -178,6 +181,7 @@ export enum EffectNames {
     LimitLegalAttackers = 'limitLegalAttackers',
     ModifyHonorTransferGiven = "modifyHonorTransferGiven",
     ModifyHonorTransferReceived = "modifyHonorTransferReceived",
+    ModifyUnopposedHonorLoss = "modifyUnopposedHonorLoss"
 };
 
 export enum Durations {
@@ -319,6 +323,7 @@ export enum EventNames {
     OnCardsDrawn = 'onCardsDrawn',
     OnLookAtCards = 'onLookAtCards',
     OnModifyBid = 'onModifyBid',
+    OnHonorBid = 'onHonorBid',
     OnModifyFate = 'onModifyFate',
     OnSetHonorDial = 'onSetHonorDial',
     OnSwitchConflictElement = 'onSwitchConflictElement',

--- a/server/game/GameActions/ClaimFavorAction.ts
+++ b/server/game/GameActions/ClaimFavorAction.ts
@@ -1,17 +1,17 @@
-import { PlayerAction, PlayerActionProperties} from './PlayerAction';
-import { EventNames } from '../Constants';
+import { PlayerAction, PlayerActionProperties } from './PlayerAction';
+import { EventNames, FavorTypes } from '../Constants';
 import AbilityContext = require('../AbilityContext');
 import Player = require('../player');
-import { GameAction, GameActionProperties } from './GameAction';
 
 export interface ClaimFavorProperties extends PlayerActionProperties {
     target: Player | null;
+    side?: FavorTypes;
 }
 
 export class ClaimFavorAction extends PlayerAction {
     name = 'claimFavor';
     eventName = EventNames.OnClaimFavor;
-    effect = 'claim the Emperor\'s favor';
+    effect = "claim the Emperor's favor";
 
     hasLegalTarget(): boolean {
         return true;
@@ -26,8 +26,10 @@ export class ClaimFavorAction extends PlayerAction {
         return properties;
     }
 
-    eventHandler(event): void {
-        if(event.player)
-            event.player.claimImperialFavor();
+    eventHandler(event, additionalProperties = {}): void {
+        let { side } = this.getProperties(event.context, additionalProperties) as ClaimFavorProperties;
+        if(event.player) {
+            event.player.claimImperialFavor(side);
+        }
     }
 }

--- a/server/game/GameActions/DishonorProvinceAction.ts
+++ b/server/game/GameActions/DishonorProvinceAction.ts
@@ -2,6 +2,7 @@ import { CardGameAction, CardActionProperties} from './CardGameAction';
 import { CardTypes, Locations, EventNames } from '../Constants';
 import AbilityContext = require('../AbilityContext');
 import BaseCard = require('../basecard');
+import ProvinceCard = require('../provincecard');
 
 export interface DishonorProvinceProperties extends CardActionProperties {
 }
@@ -12,6 +13,25 @@ export class DishonorProvinceAction extends CardGameAction {
     targetType = [CardTypes.Province];
     cost = 'dishonoring {0}';
     effect = 'dishonor {0}';
+
+    getEffectMessage(context: AbilityContext): [string, any[]] {
+        const properties = this.getProperties(context) as DishonorProvinceProperties;
+        const targetArray = [];
+        if (properties.target) {
+            if (Array.isArray(properties.target)) {
+                properties.target.forEach(t => {
+                    const target = t as ProvinceCard
+                    const targetMessage = (target && target.isFacedown && target.isFacedown()) ? target.location : target    
+                    targetArray.push(targetMessage);
+                })
+            } else {
+                const target = properties.target as ProvinceCard
+                const targetMessage = (target && target.isFacedown && target.isFacedown()) ? target.location : target    
+                targetArray.push(targetMessage);
+            }
+        }
+        return ['place a dishonored status token on {0}, blanking it', [targetArray]];    
+    }
 
     canAffect(card: BaseCard, context: AbilityContext): boolean {
         if(card.type !== CardTypes.Province || card.isDishonored) {

--- a/server/game/GameActions/GameActions.ts
+++ b/server/game/GameActions/GameActions.ts
@@ -30,6 +30,7 @@ import { GainHonorAction, GainHonorProperties } from './GainHonorAction';
 import { GainStatusTokenAction, GainStatusTokenProperties } from './GainStatusTokenAction';
 import { HandlerAction, HandlerProperties } from './HandlerAction';
 import { HonorAction, HonorProperties } from './HonorAction';
+import { HonorBidAction, HonorBidProperties } from './HonorBidAction';
 import { IfAbleAction, IfAbleActionProperties } from './IfAbleAction';
 import { InitiateConflictAction, InitiateConflictProperties } from './InitiateConflictAction';
 import { JointGameAction } from './JointGameAction';
@@ -49,6 +50,7 @@ import { MultipleGameAction } from './MultipleGameAction';
 import { MultipleContextGameAction, MultipleContextActionProperties } from './MultipleContextGameAction';
 import { PlaceCardUnderneathAction, PlaceCardUnderneathProperties } from './PlaceCardUnderneathAction';
 import { PlaceFateAction, PlaceFateProperties } from './PlaceFateAction';
+import { PlaceFateAttachmentAction, PlaceFateAttachmentProperties } from './PlaceFateAttachmentAction';
 import { PlaceFateRingAction, PlaceFateRingProperties } from './PlaceFateRingAction';
 import { PlayCardAction, PlayCardProperties } from './PlayCardAction';
 import { PutIntoPlayAction, PutIntoPlayProperties } from './PutIntoPlayAction';
@@ -116,6 +118,7 @@ const GameActions = {
     moveCard: (propertyFactory: MoveCardProperties | ((context: TriggeredAbilityContext) => MoveCardProperties)) => new MoveCardAction(propertyFactory), // destination, switch = false, shuffle = false, faceup = false
     moveToConflict: (propertyFactory: MoveToConflictProperties | ((context: TriggeredAbilityContext) => MoveToConflictProperties) = {}) => new MoveToConflictAction(propertyFactory),
     placeFate: (propertyFactory: PlaceFateProperties | ((context: TriggeredAbilityContext) => PlaceFateProperties) = {}) => new PlaceFateAction(propertyFactory), // amount = 1, origin
+    placeFateAttachment: (propertyFactory: PlaceFateAttachmentProperties | ((context: TriggeredAbilityContext) => PlaceFateAttachmentProperties) = {}) => new PlaceFateAttachmentAction(propertyFactory), // amount = 1, origin
     playCard: (propertyFactory: PlayCardProperties | ((context: TriggeredAbilityContext) => PlayCardProperties) = {}) => new PlayCardAction(propertyFactory), // resetOnCancel = false, postHandler
     performGloryCount: (propertyFactory: GloryCountProperties | ((context: TriggeredAbilityContext) => GloryCountProperties)) => new GloryCountAction(propertyFactory),
     putIntoConflict: (propertyFactory: PutIntoPlayProperties | ((context: TriggeredAbilityContext) => PutIntoPlayProperties) = {}) => new PutIntoPlayAction(propertyFactory), // fate = 0, status = ordinary
@@ -149,6 +152,7 @@ const GameActions = {
     fillProvince: (propertyFactory: FillProvinceProperties | ((context: TriggeredAbilityContext) => FillProvinceProperties)) => new FillProvinceAction(propertyFactory), // location, amount = 1, faceup = false
     gainFate: (propertyFactory: GainFateProperties | ((context: TriggeredAbilityContext) => GainFateProperties) = {}) => new GainFateAction(propertyFactory), // amount = 1
     gainHonor: (propertyFactory: GainHonorProperties | ((context: TriggeredAbilityContext) => GainHonorProperties) = {}) => new GainHonorAction(propertyFactory), // amount = 1
+    honorBid: (propertyFactory: HonorBidProperties | ((context: TriggeredAbilityContext) => HonorBidProperties) = {}) => new HonorBidAction(propertyFactory), // giveHonor = false, players = Players.Any, prohibitedBids = []
     initiateConflict: (propertyFactory: InitiateConflictProperties | ((context: TriggeredAbilityContext) => InitiateConflictProperties) = {}) => new InitiateConflictAction(propertyFactory), // canPass = true
     loseFate: (propertyFactory: LoseFateProperties | ((context: TriggeredAbilityContext) => LoseFateProperties) = {}) => new LoseFateAction(propertyFactory),
     loseHonor: (propertyFactory: LoseHonorProperties | ((context: TriggeredAbilityContext) => LoseHonorProperties) = {}) => new LoseHonorAction(propertyFactory), // amount = 1

--- a/server/game/GameActions/HonorBidAction.ts
+++ b/server/game/GameActions/HonorBidAction.ts
@@ -1,0 +1,107 @@
+import { PlayerAction, PlayerActionProperties } from './PlayerAction';
+import AbilityContext = require('../AbilityContext');
+import Player = require('../player');
+import { EventNames, Players } from '../Constants';
+import HonorBidPrompt = require('../gamesteps/honorbidprompt');
+import { GameAction } from './GameAction';
+import SimpleStep = require('../gamesteps/simplestep');
+
+export interface HonorBidProperties extends PlayerActionProperties {
+    giveHonor?: boolean;
+    prohibitedBids?: Array<number>;
+    players?: Players;
+    postBidAction?: GameAction;
+    message?: string;
+    messageArgs?: (context: AbilityContext) => any | any[];
+}
+
+export class HonorBidAction extends PlayerAction {
+    name = 'honorBid';
+    eventName = EventNames.OnHonorBid;
+    defaultProperties: HonorBidProperties = { 
+        giveHonor: false,
+        prohibitedBids: [],
+        players: Players.Any,
+        postBidAction: undefined,
+    };
+
+    constructor(propertyFactory: HonorBidProperties | ((context: AbilityContext) => HonorBidProperties)) {
+        super(propertyFactory);
+    }
+
+    defaultTargets(context) {
+        return [context.player];
+    }
+
+    getEffectMessage(context: AbilityContext): [string, any[]] {
+        let properties: HonorBidProperties = this.getProperties(context);
+        if (properties.giveHonor) {
+            return ['bid honor', []];
+        }
+
+        const players = [];
+        switch (properties.players) {
+            case Players.Any:
+                players.push(context.player);
+                players.push(context.player.opponent);
+                break;
+            case Players.Self:
+                players.push(context.player);
+                break;
+            case Players.Opponent:
+                players.push(context.player.opponent);
+                break;
+        }
+        return ['have {0} select a value on their honor dial', [players]];
+    }
+
+    addPropertiesToEvent(event, player: Player, context: AbilityContext, additionalProperties): void {
+        let { giveHonor, prohibitedBids, players, postBidAction, message, messageArgs } = this.getProperties(context, additionalProperties) as HonorBidProperties;        
+        super.addPropertiesToEvent(event, player, context, additionalProperties);
+        event.giveHonor = giveHonor;
+        event.prohibitedBids = prohibitedBids;
+        event.players = players;
+        event.postBidAction = postBidAction;
+        event.message = message;
+        event.messageArgs = messageArgs;
+    }
+
+    eventHandler(event): void {
+        let context = event.context;
+
+        if (event.players === Players.Any) {
+            let prohibitedBids = {};
+            for(const player of context.game.getPlayers()) {
+                prohibitedBids[player.uuid] = event.prohibitedBids;
+            }
+            let costHandler = undefined;
+            if (!event.giveHonor) {
+                costHandler = () => { };
+            }
+            context.game.queueStep(new HonorBidPrompt(context.game, 'Choose your bid', costHandler, prohibitedBids, null, false));
+            context.game.queueStep(new SimpleStep(context.game, () => event.postBidAction.resolve(context.player, context)));
+            context.game.queueStep(new SimpleStep(context.game, () => {
+                let message, messageArgs;
+                if(event.message) {
+                    message = event.message;
+                    messageArgs = event.messageArgs ? [].concat(event.messageArgs(context)) : [];
+                } else {
+                    [message, messageArgs] = event.postBidAction.getEffectMessage(context);
+                }
+                context.game.addMessage(message, ...messageArgs);
+            }));
+        }
+        else {
+            const player = (event.players === Players.Self) ? context.player : context.player.opponent;
+
+            event.context.game.promptWithHandlerMenu(player, {
+                activePromptTitle: 'Choose a value to set your honor dial at',
+                context: event.context,
+                choices: ['1', '2', '3', '4', '5'],
+                handlers: [1,2,3,4,5].map(value => {
+                    return () => context.game.actions.setHonorDial({ value }).resolve(player, context);
+                })
+            });
+        }
+    }
+}

--- a/server/game/GameActions/MoveToConflictAction.ts
+++ b/server/game/GameActions/MoveToConflictAction.ts
@@ -11,6 +11,7 @@ export interface MoveToConflictProperties extends CardActionProperties {
 export class MoveToConflictAction extends CardGameAction {
     name = 'moveToConflict';
     eventName = EventNames.OnMoveToConflict;
+    cost = 'moving {0} into the conflict';
     effect = 'move {0} into the conflict';
     targetType = [CardTypes.Character];
     defaultProperties: MoveToConflictProperties = { side: null };

--- a/server/game/GameActions/PlaceFateAttachmentAction.ts
+++ b/server/game/GameActions/PlaceFateAttachmentAction.ts
@@ -1,0 +1,78 @@
+import AbilityContext = require('../AbilityContext');
+import DrawCard = require('../drawcard');
+import Player = require('../player');
+import Ring = require('../ring');
+import { CardGameAction, CardActionProperties } from './CardGameAction';
+import { Locations, CardTypes, EventNames }  from '../Constants';
+import { type } from 'os';
+
+export interface PlaceFateAttachmentProperties extends CardActionProperties {
+    amount?: number,
+    origin?: DrawCard | Player | Ring
+}
+
+export class PlaceFateAttachmentAction extends CardGameAction {
+    name = 'placeFate';
+    eventName = EventNames.OnMoveFate;
+    targetType = [CardTypes.Attachment];
+    defaultProperties: PlaceFateAttachmentProperties = { amount: 1 };
+    constructor(properties: ((context: AbilityContext) => PlaceFateAttachmentProperties) | PlaceFateAttachmentProperties) {
+        super(properties);
+    }
+
+    getEffectMessage(context: AbilityContext): [string, any[]] {
+        let { amount, target } = this.getProperties(context) as PlaceFateAttachmentProperties;
+        return ['place {1} fate on {0}', [target, amount]];
+    }
+
+    canAffect(card: DrawCard, context: AbilityContext, additionalProperties = {}): boolean {
+        let { amount, origin } = this.getProperties(context, additionalProperties) as PlaceFateAttachmentProperties;
+        if(amount === 0 || card.location !== Locations.PlayArea) {
+            return false;
+        }
+
+        if(origin && this.isRing(origin) && !context.player.checkRestrictions('takeFateFromRings', context)){
+            return false;
+        }
+
+        return super.canAffect(card, context) && this.checkOrigin(origin, context) && card !== origin;
+    }
+
+    isRing(x: any): x is Ring {
+        return "element" in x;
+    }
+
+    checkOrigin(origin: Player | Ring | DrawCard, context: AbilityContext): boolean {
+        if(origin) {
+            if(origin.fate === 0) {
+                return false;
+            } else if(['player', 'ring'].includes(origin.type)) {
+                return true;
+            }
+            return origin.allowGameAction('removeFate', context);
+        }
+        return true;
+    }
+
+    addPropertiesToEvent(event, card: DrawCard, context: AbilityContext, additionalProperties): void {
+        let { amount, origin } = this.getProperties(context, additionalProperties) as PlaceFateAttachmentProperties;
+        event.fate = amount;
+        event.origin = origin;
+        event.context = context;
+        event.recipient = card;
+    }
+
+    checkEventCondition(event): boolean {
+        return this.moveFateEventCondition(event);
+    }
+
+    isEventFullyResolved(event, card: DrawCard, context: AbilityContext, additionalProperties): boolean {
+        let { amount, origin } = this.getProperties(context, additionalProperties) as PlaceFateAttachmentProperties;
+        return !event.cancelled && event.name === this.eventName &&
+            event.fate === amount && event.origin === origin && event.recipient === card;
+    }
+
+    eventHandler(event): void {
+        this.moveFateEventHandler(event);
+    }
+}

--- a/server/game/GameActions/SendHomeAction.ts
+++ b/server/game/GameActions/SendHomeAction.ts
@@ -9,6 +9,7 @@ export interface SendHomeProperties extends CardActionProperties {
 export class SendHomeAction extends CardGameAction {
     name = 'sendHome';
     eventName = EventNames.OnSendHome;
+    cost = 'moving home {0}';
     effect = 'send {0} home';
     targetType = [CardTypes.Character];
 

--- a/server/game/Interfaces.ts
+++ b/server/game/Interfaces.ts
@@ -197,7 +197,8 @@ export interface AttachmentConditionProps {
     unique?: boolean;
     faction?: string | string[];
     trait?: string | string[];
-    limitTrait?: traitLimit | traitLimit[]
+    limitTrait?: traitLimit | traitLimit[],
+    cardCondition?: (card: BaseCard) => boolean 
 };
 
 interface HonoredToken {

--- a/server/game/PlayDisguisedCharacterAction.js
+++ b/server/game/PlayDisguisedCharacterAction.js
@@ -52,12 +52,13 @@ class DisguisedReduceableFateCost extends ReduceableFateCost {
 }
 
 class PlayDisguisedCharacterAction extends BaseAction {
-    constructor(card, intoConflictOnly = false) {
+    constructor(card, intoConflictOnly = false, intoPlayOnly = false) {
         super(card, [
             ChooseDisguisedCharacterCost(intoConflictOnly),
             new DisguisedReduceableFateCost(intoConflictOnly)
         ]);
         this.intoConflictOnly = intoConflictOnly;
+        this.intoPlayOnly = intoPlayOnly;
         this.title = 'Play this character with Disguise';
     }
 
@@ -100,7 +101,7 @@ class PlayDisguisedCharacterAction extends BaseAction {
         const frameworkKeepsDisguisedInCurrentLocation = context.game.gameMode === GameModes.Emerald || context.game.gameMode === GameModes.Obsidian;
         const conflictOnly = this.intoConflictOnly || (frameworkKeepsDisguisedInCurrentLocation && replacedCharacter.isParticipating());
 
-        let intoConflict = conflictOnly;
+        let intoConflict = conflictOnly && !this.intoPlayOnly;
         if(replacedCharacter.inConflict && !conflictOnly) {
             context.game.promptWithHandlerMenu(context.player, {
                 activePromptTitle: 'Where do you wish to play this character?',

--- a/server/game/cards/01-Core/AsakoDiplomat.js
+++ b/server/game/cards/01-Core/AsakoDiplomat.js
@@ -16,7 +16,7 @@ class AsakoDiplomat extends DrawCard {
                 gameAction: AbilityDsl.actions.chooseAction({
                     messages: {
                         'Honor this character': '{0} chooses to honor {1}',
-                        'Dishonor this character': '{0} chooses to honor {1}'
+                        'Dishonor this character': '{0} chooses to dishonor {1}'
                     },
                     choices: {
                         'Honor this character': AbilityDsl.actions.honor(),

--- a/server/game/cards/06-CotE/SmugglingDeal.js
+++ b/server/game/cards/06-CotE/SmugglingDeal.js
@@ -15,7 +15,9 @@ class SmugglingDeal extends DrawCard {
                 gameAction: AbilityDsl.actions.cardLastingEffect(context => ({
                     target: context.targetAbility.card,
                     duration: Durations.UntilEndOfRound,
-                    effect: AbilityDsl.effects.increaseLimitOnAbilities(context.targetAbility)
+                    effect: AbilityDsl.effects.increaseLimitOnAbilities({
+                        targetAbility: context.targetAbility
+                    })
                 }))
             },
             effect: 'increase the limit on {1}\'s \'{2}\' ability',

--- a/server/game/cards/14.3-IPoT/ReturnFromShadows.js
+++ b/server/game/cards/14.3-IPoT/ReturnFromShadows.js
@@ -18,9 +18,7 @@ class ReturnFromShadows extends DrawCard {
                     AbilityDsl.actions.dishonorProvince(),
                     AbilityDsl.actions.reveal({ chatMessage: true })
                 ])
-            },
-            effect: 'place a dishonor token on {1}, blanking it',
-            effectArgs: context => [context.target.isFacedown() ? context.target.location : context.target]
+            }
         });
     }
 }

--- a/server/game/cards/15.4-TToTS/MeticulousScout.js
+++ b/server/game/cards/15.4-TToTS/MeticulousScout.js
@@ -15,9 +15,7 @@ class MeticulousScout extends DrawCard {
                     AbilityDsl.actions.dishonorProvince(),
                     AbilityDsl.actions.reveal({ chatMessage: true })
                 ])
-            },
-            effect: 'place a dishonor token on {1}, blanking it',
-            effectArgs: context => [context.target.isFacedown() ? context.target.location : context.target]
+            }
         });
     }
 }

--- a/server/game/cards/15.5-CoP/Overrun.js
+++ b/server/game/cards/15.5-CoP/Overrun.js
@@ -18,9 +18,7 @@ class Overrun extends DrawCard {
                     AbilityDsl.actions.dishonorProvince(),
                     AbilityDsl.actions.reveal({ chatMessage: true })
                 ])
-            },
-            effect: 'place a dishonor token on {1}, blanking it',
-            effectArgs: context => [context.target.isFacedown() ? context.target.location : context.target]
+            }
         });
     }
 }

--- a/server/game/cards/16-UFLS/JadeTalisman.js
+++ b/server/game/cards/16-UFLS/JadeTalisman.js
@@ -10,7 +10,7 @@ class JadeTalisman extends DrawCard {
         this.wouldInterrupt({
             title: 'Cancel a ring effect',
             when: {
-                onMoveFate: (event, context) => event.origin === context.source.parent && event.fate > 0 && event.context.source.type === 'ring',
+                onMoveFate: (event, context) => event.context.source.type === 'ring' && event.origin === context.source.parent && event.fate > 0,
                 onCardHonored: (event, context) => event.card === context.source.parent && event.context.source.type === 'ring',
                 onCardDishonored: (event, context) => event.card === context.source.parent && event.context.source.type === 'ring',
                 onCardBowed: (event, context) => event.card === context.source.parent && event.context.source.type === 'ring',

--- a/server/game/cards/18.1-EL01/Lion/NobleVanguard.js
+++ b/server/game/cards/18.1-EL01/Lion/NobleVanguard.js
@@ -1,7 +1,7 @@
 const DrawCard = require('../../../drawcard.js');
 const { CardTypes, Players, Locations } = require('../../../Constants');
 const AbilityDsl = require('../../../abilitydsl');
-const Soldier = require('../../Soldier.js');
+const { default: Soldier } = require('../../Soldier');
 
 class NobleVanguard extends DrawCard {
     setupCardAbilities() {

--- a/server/game/cards/18.1-EL01/Lion/Pride.js
+++ b/server/game/cards/18.1-EL01/Lion/Pride.js
@@ -1,10 +1,11 @@
 const StrongholdCard = require('../../../strongholdcard.js');
 const { CardTypes, Players, Locations } = require('../../../Constants');
 const AbilityDsl = require('../../../abilitydsl.js');
-const Soldier = require('../../Soldier.js');
+const { default: Soldier } = require('../../Soldier');
 
 class Pride extends StrongholdCard {
     setupCardAbilities() {
+        // @ts-ignore
         const DummyAttachment = new Soldier(this);
 
         this.action({

--- a/server/game/cards/19.1-AS01/Crab/BloodthirstyOnryo.js
+++ b/server/game/cards/19.1-AS01/Crab/BloodthirstyOnryo.js
@@ -1,0 +1,33 @@
+const DrawCard = require('../../../drawcard.js');
+const { Locations, CardTypes } = require('../../../Constants');
+const EventRegistrar = require('../../../eventregistrar');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+class BloodthirstyOnryo extends DrawCard {
+    setupCardAbilities() {
+        this.eventRegistrar = new EventRegistrar(this.game, this);
+        this.eventRegistrar.register(['onCardLeavesPlay']);
+
+        this.action({
+            title: 'Put this into play',
+            cost: AbilityDsl.costs.sacrifice({
+                cardType: CardTypes.Character
+            }),
+            location: [Locations.Provinces, Locations.DynastyDiscardPile],
+            gameAction: AbilityDsl.actions.putIntoPlay()
+        });
+    }
+
+    onCardLeavesPlay(event) {
+        if(event.card === this) {
+            if(this.location !== Locations.RemovedFromGame) {
+                this.game.addMessage('{0} is removed from the game due to leaving play', this);
+                this.owner.moveCard(this, Locations.RemovedFromGame);
+            }
+        }
+    }
+}
+
+BloodthirstyOnryo.id = 'bloodthirsty-onryo';
+
+module.exports = BloodthirstyOnryo;

--- a/server/game/cards/19.1-AS01/Crab/BrokenBlades.js
+++ b/server/game/cards/19.1-AS01/Crab/BrokenBlades.js
@@ -1,0 +1,49 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, Players, ConflictTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class BrokenBlades extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Return all fate from a character then discard them',
+            effect: 'ensure {0} is gone!{1}{2}{3}',
+            effectArgs: (context) =>
+                context.target.fate < 1
+                    ? []
+                    : [
+                        ' (',
+                        context.target.owner,
+                        ' recovers ' + context.target.fate + ' fate)'
+                    ],
+            when: {
+                afterConflict: (event, context) =>
+                    context.player.isAttackingPlayer() &&
+                    event.conflict.winner === context.player &&
+                    event.conflict.conflictType === ConflictTypes.Military
+            },
+
+            cost: AbilityDsl.costs.sacrifice({
+                cardType: CardTypes.Character,
+                cardCondition: (card) =>
+                    card.isParticipating() && card.hasTrait('berserker')
+            }),
+            target: {
+                cardType: CardTypes.Character,
+                controller: Players.Opponent,
+                cardCondition: (card) => card.isParticipating(),
+                gameAction: AbilityDsl.actions.sequential([
+                    AbilityDsl.actions.removeFate((context) => ({
+                        amount: context.target.getFate(),
+                        recipient: context.target.owner
+                    })),
+                    AbilityDsl.actions.discardFromPlay()
+                ])
+            },
+            max:AbilityDsl.limit.perConflict(1)
+        });
+    }
+}
+
+BrokenBlades.id = 'broken-blades';
+
+module.exports = BrokenBlades;

--- a/server/game/cards/19.1-AS01/Crab/CinderSalamander.js
+++ b/server/game/cards/19.1-AS01/Crab/CinderSalamander.js
@@ -1,0 +1,81 @@
+const DrawCard = require('../../../drawcard.js');
+const { Locations, Elements, Decks, TargetModes, Players, CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+const elementKey = 'cinder-salamander-fire';
+
+class CinderSalamander extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Shuffle this character back into the deck',
+            location: Locations.DynastyDiscardPile,
+            when: {
+                onCardLeavesPlay: (event, context) => event.card === context.source
+            },
+            gameAction: AbilityDsl.actions.moveCard({
+                destination: Locations.DynastyDeck,
+                shuffle: true
+            })
+        });
+
+        this.action({
+            title: 'Search other copies of this character and put them into play',
+            condition: (context) =>
+                this.game.rings[this.getCurrentElementSymbol(elementKey)].isConsideredClaimed(context.player),
+
+            gameAction: AbilityDsl.actions.multiple([
+                AbilityDsl.actions.deckSearch({
+                    activePromptTitle: 'Select characters to put into play from your deck',
+                    deck: Decks.DynastyDeck,
+                    targetMode: TargetModes.UpTo,
+                    numCards: 3,
+                    cardCondition: (card) => this.isSalamanderCard(card),
+                    shuffle: true,
+                    gameAction: AbilityDsl.actions.putIntoPlay(),
+                    message: '{0} finds {1} in their deck',
+                    messageArgs: (context, cards) => [context.player, this.salamanderCountToText(cards.length)]
+                }),
+                AbilityDsl.actions.selectCard({
+                    activePromptTitle: 'Select characters to put into play from your provinces',
+                    controller: Players.Self,
+                    cardType: CardTypes.Character,
+                    location: Locations.Provinces,
+                    mode: TargetModes.UpTo,
+                    numCards: 3,
+                    cardCondition: (card) => this.isSalamanderCard(card),
+                    gameAction: AbilityDsl.actions.putIntoPlay(),
+                    message: '{0} finds {1} in their provinces',
+                    messageArgs: (cards, player) => [player, this.salamanderCountToText(cards.length)]
+                })
+            ]),
+            effect: 'search their deck and provinces for other copies of {0} and put them into play',
+            max: AbilityDsl.limit.perRound(1)
+        });
+    }
+
+    getPrintedElementSymbols() {
+        let symbols = super.getPrintedElementSymbols();
+        symbols.push({
+            key: elementKey,
+            prettyName: 'Claimed Ring',
+            element: Elements.Fire
+        });
+        return symbols;
+    }
+
+    isSalamanderCard(card) {
+        return card.id === this.id;
+    }
+
+    salamanderCountToText(salamanderCount) {
+        return salamanderCount > 1
+            ? salamanderCount + ' salamanders'
+            : salamanderCount === 1
+                ? '1 salamander'
+                : 'no salamanders';
+    }
+}
+
+CinderSalamander.id = 'cinder-salamander';
+
+module.exports = CinderSalamander;

--- a/server/game/cards/19.1-AS01/Crab/EarnestSculptor.js
+++ b/server/game/cards/19.1-AS01/Crab/EarnestSculptor.js
@@ -1,0 +1,58 @@
+const DrawCard = require('../../../drawcard.js');
+const { Locations, CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+const PlayAttachmentAction = require('../../../playattachmentaction.js');
+
+class EarnestSculptor extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Search top 5 card for a spell',
+            effect: 'look at the top five cards of their deck',
+            gameAction: AbilityDsl.actions.deckSearch({
+                amount: 5,
+                cardCondition: (card) => card.hasTrait('spell'),
+                gameAction: AbilityDsl.actions.moveCard({
+                    destination: Locations.Hand
+                })
+            })
+        });
+
+        this.interrupt({
+            title: 'Reduce cost of next Jade card',
+            when: {
+                onCardPlayed: (event, context) =>
+                    // Event
+                    event.card.type === CardTypes.Event &&
+                    // by player
+                    event.player === context.player &&
+                    // jade
+                    event.card.hasTrait('jade') &&
+                    // costing more than zero
+                    event.context.ability.getReducedCost(event.context) > 0,
+                onAbilityResolverInitiated: (event, context) =>
+                    // Attachment
+                    (event.context.source.type === CardTypes.Attachment ||
+                        event.context.ability instanceof PlayAttachmentAction) &&
+                    // by player
+                    event.context.player === context.player &&
+                    // jade
+                    event.context.source.hasTrait('jade') &&
+                    // costing more than zero
+                    event.context.ability.getReducedCost(event.context) > 0
+            },
+            effect: 'reduce the cost of {1} by 1',
+            effectArgs: (context) => [context.event.context.source],
+            gameAction: AbilityDsl.actions.playerLastingEffect((context) => ({
+                targetController: context.player,
+                effect: AbilityDsl.effects.reduceNextPlayedCardCost(
+                    1,
+                    (card) => card === context.event.card || card === context.event.context.source
+                )
+            }))
+        });
+    }
+}
+
+EarnestSculptor.id = 'earnest-sculptor';
+
+module.exports = EarnestSculptor;

--- a/server/game/cards/19.1-AS01/Crab/KuniJuurou.js
+++ b/server/game/cards/19.1-AS01/Crab/KuniJuurou.js
@@ -1,0 +1,53 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, Players, Phases } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+class KuniJuurou extends DrawCard {
+    setupCardAbilities() {
+        this.cannotPayHonorCostsEffect();
+
+        this.persistentEffect({
+            targetController: Players.Any,
+            match: (card) =>
+                card.type === CardTypes.Character &&
+                (card.isTainted || card.hasTrait('shadowlands') || card.hasTrait('haunted')),
+            effect: AbilityDsl.effects.modifyBothSkills(-2)
+        });
+
+        this.action({
+            title: 'Taint a character',
+            effect: 'identify the source of Crab\'s misfortune… it is {0}! {0} is tainted.',
+            phase: Phases.Conflict,
+            condition: (context) =>
+                context.player.opponent && context.player.hand.size() <= context.player.opponent.hand.size(),
+            target: {
+                cardType: CardTypes.Character,
+                gameAction: AbilityDsl.actions.taint()
+            }
+        });
+    }
+
+    cannotPayHonorCostsEffect() {
+        this.persistentEffect({
+            effect: AbilityDsl.effects.playerCannot({ cannot: 'loseHonor', restricts: 'loseHonorAsCost' })
+        });
+
+        /**
+         * Shortcut to handle tainted characters.
+         * Ideally it would be integrated when generating the conflict matrix etc.
+         * Without this Tainted character get stopped from commiting into the conflict, but the declaration goes through
+         */
+        this.persistentEffect({
+            match: (card) => card.controller === this.controller && card.isTainted,
+            effect: AbilityDsl.effects.cardCannot('declareAsAttacker')
+        });
+        this.persistentEffect({
+            match: (card) => card.controller === this.controller && card.isTainted,
+            effect: AbilityDsl.effects.cardCannot('declareAsDefender')
+        });
+    }
+}
+
+KuniJuurou.id = 'kuni-juurou';
+
+module.exports = KuniJuurou;

--- a/server/game/cards/19.1-AS01/Crab/OutmaneuveredByForce.js
+++ b/server/game/cards/19.1-AS01/Crab/OutmaneuveredByForce.js
@@ -1,0 +1,39 @@
+const DrawCard = require('../../../drawcard.js');
+const { Players, CardTypes, Phases } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class OutmaneuveredByForce extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Declare a conflict right now',
+            phase: Phases.Conflict,
+            condition: (context) =>
+                context.game
+                    .getConflicts(Players.Any)
+                    .filter((conflict) => conflict.declared).length === 0,
+
+            gameAction: AbilityDsl.actions.initiateConflict({ canPass: false })
+        });
+    }
+
+    canPlay(context, playType) {
+        if(context.game.isDuringConflict()) {
+            return false;
+        }
+        if(
+            !context.player.cardsInPlay.any(
+                (card) =>
+                    card.getType() === CardTypes.Character &&
+                    (card.hasTrait('berserker') || card.printedMilitarySkill >= 6)
+            )
+        ) {
+            return false;
+        }
+
+        return super.canPlay(context, playType);
+    }
+}
+
+OutmaneuveredByForce.id = 'outmaneuvered-by-force';
+
+module.exports = OutmaneuveredByForce;

--- a/server/game/cards/19.1-AS01/Crab/ProtectedMerchant.js
+++ b/server/game/cards/19.1-AS01/Crab/ProtectedMerchant.js
@@ -1,0 +1,28 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class ProtectedMerchant extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            effect: AbilityDsl.effects.modifyGlory(() => Math.min(2, this.getHoldingsInPlay()))
+        });
+    }
+
+    getHoldingsInPlay() {
+        return this.game.allCards.reduce(
+            (sum, card) =>
+                card.type === CardTypes.Holding &&
+                card.controller === this.controller &&
+                card.isFaceup() &&
+                card.isInProvince()
+                    ? sum + 1
+                    : sum,
+            0
+        );
+    }
+}
+
+ProtectedMerchant.id = 'protected-merchant';
+
+module.exports = ProtectedMerchant;

--- a/server/game/cards/19.1-AS01/Crab/ShoreOfTheAshenFlames.js
+++ b/server/game/cards/19.1-AS01/Crab/ShoreOfTheAshenFlames.js
@@ -1,0 +1,40 @@
+const AbilityDsl = require('../../../abilitydsl.js');
+const { Players, ConflictTypes, EffectNames, CardTypes } = require('../../../Constants');
+const ProvinceCard = require('../../../provincecard.js');
+
+class ShoreOfTheAshenFlames extends ProvinceCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            condition: context => context.source.isConflictProvince(),
+            targetController: Players.Opponent,
+            effect: AbilityDsl.effects.changeConflictSkillFunctionPlayer((card, conflict) => {
+                const exclusionFunction = (effect) => {
+                    if(effect.type === EffectNames.AttachmentMilitarySkillModifier) {
+                        const value = effect.getValue(card);
+                        return value > 0;
+                    }
+                    if(effect.type === EffectNames.AttachmentPoliticalSkillModifier) {
+                        const value = effect.getValue(card);
+                        return value > 0;
+                    }
+                    if(effect.type === EffectNames.ModifyMilitarySkill || effect.type === EffectNames.ModifyPoliticalSkill || effect.type === EffectNames.ModifyBothSkills) {
+                        if(effect.context && effect.context.source) {
+                            const source = effect.context.source;
+                            return source && source.type === CardTypes.Attachment;
+                        }
+                        return false;
+                    }
+                };
+
+                if(conflict.conflictType === ConflictTypes.Military) {
+                    return card.getMilitarySkillExcludingModifiers(exclusionFunction);
+                }
+                return card.getPoliticalSkillExcludingModifiers(exclusionFunction);
+            })
+        });
+    }
+}
+
+ShoreOfTheAshenFlames.id = 'shore-of-the-ashen-flames';
+
+module.exports = ShoreOfTheAshenFlames;

--- a/server/game/cards/19.1-AS01/Crane/ArrowsFromTheWoods.js
+++ b/server/game/cards/19.1-AS01/Crane/ArrowsFromTheWoods.js
@@ -1,0 +1,31 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+class ArrowsFromTheWoods extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Reduce opponent\'s characters mil',
+            condition: (context) =>
+                context.game.isDuringConflict('military') &&
+                context.player.anyCardsInPlay((card) => card.isParticipating() && card.hasTrait('bushi')),
+            gameAction: AbilityDsl.actions.cardLastingEffect((context) => ({
+                target: context.game.currentConflict.getCharacters(context.player.opponent),
+                effect: AbilityDsl.effects.modifyMilitarySkill(this._arrowsPenalty(context))
+            })),
+            effect: 'give {1}\'s participating characters {2}{3}',
+            effectArgs: (context) => [context.player.opponent, this._arrowsPenalty(context), 'military'],
+            max: AbilityDsl.limit.perConflict(1)
+        });
+    }
+
+    _arrowsPenalty(context) {
+        let hasScoutOrShinobiParticipating = context.player.anyCardsInPlay(
+            (card) => card.isParticipating() && (card.hasTrait('scout') || card.hasTrait('shinobi'))
+        );
+        return hasScoutOrShinobiParticipating ? -2 : -1;
+    }
+}
+
+ArrowsFromTheWoods.id = 'arrows-from-the-woods';
+
+module.exports = ArrowsFromTheWoods;

--- a/server/game/cards/19.1-AS01/Crane/DaidojiAhma.js
+++ b/server/game/cards/19.1-AS01/Crane/DaidojiAhma.js
@@ -1,0 +1,35 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl.js');
+const { Locations } = require('../../../Constants');
+
+class DaidojiAhma extends DrawCard {
+    cardMatches(card, context) {
+        return card.isDishonored && card.controller === context.player && card.location === Locations.PlayArea && card.isFaction('crane');
+    }
+
+    setupCardAbilities() {
+        this.wouldInterrupt({
+            title: 'Cancel ability',
+            when: {
+                onInitiateAbilityEffects: (event, context) => event.context.ability.isTriggeredAbility() && event.cardTargets.some(card => (
+                    this.cardMatches(card, context)
+                )),
+                onMoveFate: (event, context) => event.context.source.type === 'ring' && this.cardMatches(event.origin, context) && event.fate > 0,
+                onCardHonored: (event, context) => event.context.source.type === 'ring' && this.cardMatches(event.card, context),
+                onCardDishonored: (event, context) => event.context.source.type === 'ring' && this.cardMatches(event.card, context),
+                onCardBowed: (event, context) => event.context.source.type === 'ring' && this.cardMatches(event.card, context),
+                onCardReadied: (event, context) => event.context.source.type === 'ring' && this.cardMatches(event.card, context)
+            },
+            gameAction: AbilityDsl.actions.cancel(),
+            effect: 'cancel the effects of {1}{2}',
+            effectArgs: context => [
+                context.event.context.source.type === 'ring' ? 'the ' : '',
+                context.event.context.source
+            ]
+        });
+    }
+}
+
+DaidojiAhma.id = 'daidoji-ahma';
+
+module.exports = DaidojiAhma;

--- a/server/game/cards/19.1-AS01/Crane/DaidojiAmbusher.js
+++ b/server/game/cards/19.1-AS01/Crane/DaidojiAmbusher.js
@@ -1,0 +1,54 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl.js');
+const { CardTypes } = require('../../../Constants');
+
+class DaidojiAmbusher extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Give someone -2 military',
+            condition: (context) => context.game.isDuringConflict('military') && context.source.isParticipating(),
+            target: {
+                cardType: CardTypes.Character,
+                cardCondition: (card) => card.isParticipating(),
+                gameAction: AbilityDsl.actions.sequential([
+                    AbilityDsl.actions.cardLastingEffect({
+                        effect: AbilityDsl.effects.modifyMilitarySkill(-2)
+                    }),
+                    AbilityDsl.actions.conditional({
+                        condition: (context) => this._ambusherDoFollowUp(context, false),
+                        trueGameAction: AbilityDsl.actions.conditional({
+                            condition: (context) => this._ambusherShouldDiscard(context),
+                            trueGameAction: AbilityDsl.actions.discardFromPlay(),
+                            falseGameAction: AbilityDsl.actions.removeFate()
+                        }),
+                        falseGameAction: AbilityDsl.actions.noAction()
+                    })
+                ])
+            },
+            effect: 'give {0} -2{1}{2}',
+            effectArgs: (context) => [
+                'military',
+                this._ambusherDoFollowUp(context, true)
+                    ? ` and ${this._ambusherShouldDiscard(context) ? 'discard them' : 'remove a fate from them'}`
+                    : ''
+            ]
+        });
+    }
+
+    _ambusherDoFollowUp(context, preResolution) {
+        const isDishonored = context.source.isDishonored;
+        const targetZero = preResolution
+            ? context.target.getMilitarySkill() <= 2
+            : context.target.getMilitarySkill() === 0;
+
+        return isDishonored && targetZero;
+    }
+
+    _ambusherShouldDiscard(context) {
+        return context.target.getFate() === 0;
+    }
+}
+
+DaidojiAmbusher.id = 'daidoji-ambusher';
+
+module.exports = DaidojiAmbusher;

--- a/server/game/cards/19.1-AS01/Crane/DesperateAide.js
+++ b/server/game/cards/19.1-AS01/Crane/DesperateAide.js
@@ -1,0 +1,35 @@
+const DrawCard = require('../../../drawcard.js');
+const { AbilityTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+class DesperateAide extends DrawCard {
+    setupCardAbilities() {
+        this.composure({
+            effect: AbilityDsl.effects.gainAbility(AbilityTypes.Action, {
+                title: 'Draw a card',
+                condition: context => context.source.isParticipating(),
+                gameAction: AbilityDsl.actions.sequential([
+                    AbilityDsl.actions.draw(context => ({ target: context.player })),
+                    AbilityDsl.actions.gainHonor(context => {
+                        let diff = this.game.currentConflict.attackerSkill - this.game.currentConflict.defenderSkill;
+                        const winning = context.player.isAttackingPlayer() ? diff > 0 : diff < 0;
+                        return {
+                            amount: winning ? 1 : 0,
+                            target: context.player
+                        };
+                    })
+                ]),
+                effect: 'draw 1 card{1}',
+                effectArgs: context => {
+                    let diff = this.game.currentConflict.attackerSkill - this.game.currentConflict.defenderSkill;
+                    const winning = context.player.isAttackingPlayer() ? diff > 0 : diff < 0;
+                    return [winning ? ' and gain 1 honor' : ''];
+                }
+            })
+        });
+    }
+}
+
+DesperateAide.id = 'desperate-aide';
+
+module.exports = DesperateAide;

--- a/server/game/cards/19.1-AS01/Crane/DevelopingMasterpiece.js
+++ b/server/game/cards/19.1-AS01/Crane/DevelopingMasterpiece.js
@@ -1,0 +1,114 @@
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Locations, Phases, PlayTypes } = require('../../../Constants');
+const DrawCard = require('../../../drawcard.js');
+
+const captureParentCost = function () {
+    return {
+        action: { name: 'captureParentCost', getCostMessage: () => '' },
+        canPay: function () {
+            return true;
+        },
+        resolve: function (context) {
+            context.costs.captureParentCost = context.source.parent;
+        },
+        pay: function () {}
+    };
+};
+
+class DevelopingMasterpiece extends DrawCard {
+    setupCardAbilities() {
+        this.whileAttached({
+            effect: [AbilityDsl.effects.cannotParticipateAsAttacker(), AbilityDsl.effects.cannotParticipateAsDefender()]
+        });
+
+        this.persistentEffect({
+            location: Locations.ConflictDiscardPile,
+            effect: AbilityDsl.effects.canPlayFromOwn(Locations.ConflictDiscardPile, [this], this, PlayTypes.Other)
+        });
+
+        this.action({
+            title: 'Gain honor',
+            phase: Phases.Fate,
+            condition: (context) => context.source.parent,
+            cost: [captureParentCost(), AbilityDsl.costs.removeSelfFromGame()],
+            gameAction: AbilityDsl.actions.gainHonor((context) => ({
+                amount: this._masterpieceHonorAmount(context),
+                target: context.player
+            })),
+            effect: 'gain {1} honor',
+            effectArgs: (context) => [this._masterpieceHonorAmount(context)],
+            then: (context) => {
+                const haiku = randomHaiku();
+                if(haiku) {
+                    haiku.forEach((line) => context.game.addMessage(`>> ${line}`));
+                    context.game.addMessage('>>>> Matsuo Bashō <<<<');
+                }
+            }
+        });
+    }
+
+    canAttach(card) {
+        if(card.controller !== this.controller) {
+            return false;
+        }
+
+        if(
+            card.getType() === CardTypes.Character &&
+            (card.hasTrait('courtier') || card.hasTrait('artisan') || card.isFaction('crane'))
+        ) {
+            return super.canAttach(card);
+        }
+        return false;
+    }
+
+    canPlay(context, playType) {
+        if(context.game.currentPhase !== Phases.Draw) {
+            return false;
+        }
+
+        return super.canPlay(context, playType);
+    }
+
+    _masterpieceHonorAmount(context) {
+        return context.costs.captureParentCost
+            ? context.costs.captureParentCost.getGlory()
+            : context.source.parent.getGlory();
+    }
+}
+
+DevelopingMasterpiece.id = 'developing-masterpiece';
+
+module.exports = DevelopingMasterpiece;
+
+/**
+ * @see https://www.carlsensei.com/classical/index.php/author/view/1
+ */
+
+const haikus = [
+    ['Ah! The ancient pond', 'As a frog takes the plunge', 'Sound of the water'],
+    ['The octopus\' fleeting dream', 'in the trap', 'the summer moon'],
+    ['Another year is gone;', 'and I still wear', 'straw hat and straw sandal.'],
+    ['Along this road', 'Goes no one,', 'This autumn eve.'],
+    ['Sick on a journey,', 'my dreams wander', 'the withered fields'],
+    ['Even in Kyoto—', 'hearing the cuckoo\'s cry—', 'I long for Kyoto'],
+    ['One field', 'did they plant.', 'I, under the willow.'],
+    ['This pervasive silence', 'Enhanced yet by cicadas simmering', 'Into the Temple Rocks dissipating'],
+    ['Dividing like clam', 'and shell, I leave for Futami—', 'Autumn is passing by'],
+    ['Turbulent the sea—', 'across to Sado stretches', 'the Milky Way'],
+    ['Plagued by fleas and lice,', 'I hear the horses stalling', 'Right by my pillow'],
+    ['Underneath the trees', 'soups and salads are buried', 'in cherry blossoms'],
+    ['The true beginnings', 'Of poetry—an Oku', 'Rice-planting song'],
+    ['The man in the moon', 'Has become homeless;', 'Rain clouded night'],
+    ['Though I would move the grave,', 'my teary cry', 'was lost in the autumn wind.'],
+    ['I am one', 'Who eats his breakfast,', 'Gazing at morning glories.'],
+    ['Deep autumn—', 'my neighbor,', 'how does he live, I wonder?'],
+    ['Not this human sadness,', 'cuckoo,', 'but your solitary cry.'],
+    ['Sad nodes', 'we\'re all the bamboo\'s children', 'in the end'],
+    ['Sweet-smelling rice fields!', 'To our right as we push through,', 'The Ariso Sea.'],
+    ['The whitebait', 'opens its eye', 'in the net of the law'],
+    ['Should I take it in my hand,', 'it would disappear with my hot tears,', 'like the frost of autumn.'],
+    ['The summer grasses—', 'Of the brave soldiers\' dreams', 'The aftermath.']
+];
+function randomHaiku() {
+    return haikus[Math.floor(haikus.length * Math.random())];
+}

--- a/server/game/cards/19.1-AS01/Crane/ForestOfRustlingWhispers.js
+++ b/server/game/cards/19.1-AS01/Crane/ForestOfRustlingWhispers.js
@@ -1,0 +1,31 @@
+const { CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+const ProvinceCard = require('../../../provincecard.js');
+
+class ForestOfRustlingWhispers extends ProvinceCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Honor or dishonor a character',
+            effect: 'honor or dishonor {0}',
+            target: {
+                activePromptTitle: 'Choose a character to honor or dishonor',
+                cardType: CardTypes.Character,
+                cardCondition: card => card.isParticipating(),
+                gameAction: AbilityDsl.actions.chooseAction({
+                    messages: {
+                        'Honor this character': '{0} chooses to honor {1}',
+                        'Dishonor this character': '{0} chooses to dishonor {1}'
+                    },
+                    choices: {
+                        'Honor this character': AbilityDsl.actions.honor(),
+                        'Dishonor this character': AbilityDsl.actions.dishonor()
+                    }
+                })
+            }
+        });
+    }
+}
+
+ForestOfRustlingWhispers.id = 'forest-of-rustling-whispers';
+
+module.exports = ForestOfRustlingWhispers;

--- a/server/game/cards/19.1-AS01/Crane/NaturesWrath.js
+++ b/server/game/cards/19.1-AS01/Crane/NaturesWrath.js
@@ -1,0 +1,88 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, Players, TargetModes, EventNames } = require('../../../Constants');
+
+class NaturesWrath extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Dishonor or move home a character',
+            condition: (context) => context.player.anyCardsInPlay((card) => card.isParticipating()),
+            targets: {
+                character: {
+                    cardType: CardTypes.Character,
+                    controller: Players.Opponent,
+                    cardCondition: (card) => card.isParticipating()
+                },
+                select: {
+                    mode: TargetModes.Select,
+                    dependsOn: 'character',
+                    player: Players.Opponent,
+                    choices: {
+                        'Dishonor this character': ability.actions.dishonor((context) => ({
+                            target: context.targets.character
+                        })),
+                        'Move this character home': ability.actions.sendHome((context) => ({
+                            target: context.targets.character
+                        }))
+                    }
+                }
+            },
+            then: (context) => {
+                if(!context.subResolution) {
+                    return {
+                        target: {
+                            mode: TargetModes.Select,
+                            choices: {
+                                'Dishonor a participating character to resolve this ability again':
+                                    this.selfDishonorSelect(
+                                        ability,
+                                        '{0} chooses to dishonor {1} to resolve {2} again'
+                                    ),
+                                Done: () => true
+                            }
+                        },
+                        then: {
+                            thenCondition: (event) =>
+                                event.origin === context.target &&
+                                !event.cancelled &&
+                                event.name === EventNames.OnCardDishonored,
+                            gameAction: ability.actions.resolveAbility({
+                                ability: context.ability,
+                                subResolution: true,
+                                choosingPlayerOverride: context.choosingPlayerOverride
+                            })
+                        }
+                    };
+                }
+                return {
+                    target: {
+                        mode: TargetModes.Select,
+                        choices: {
+                            'Dishonor a participating character for no effect': this.selfDishonorSelect(
+                                ability,
+                                '{0} chooses to dishonor {1} for no effect'
+                            ),
+                            Done: () => true
+                        }
+                    }
+                };
+            },
+            cannotTargetFirst: true,
+            max: ability.limit.perConflict(1)
+        });
+    }
+
+    selfDishonorSelect(ability, message) {
+        return ability.actions.selectCard((context) => ({
+            cardType: CardTypes.Character,
+            controller: Players.Self,
+            cardCondition: (card) => card.isParticipating(),
+            gameAction: ability.actions.dishonor(),
+            message: message,
+            messageArgs: (card) => [context.player, card, context.source]
+        }));
+    }
+}
+
+NaturesWrath.id = 'nature-s-wrath';
+
+module.exports = NaturesWrath;

--- a/server/game/cards/19.1-AS01/Crane/StormFromSakkaku.js
+++ b/server/game/cards/19.1-AS01/Crane/StormFromSakkaku.js
@@ -1,0 +1,62 @@
+const DrawCard = require('../../../drawcard.js');
+const { EventNames, CardTypes, AbilityTypes, Locations, Players } = require('../../../Constants');
+const EventRegistrar = require('../../../eventregistrar.js');
+const AbilityDsl = require('../../../abilitydsl');
+
+class StormFromSakkaku extends DrawCard {
+    setupCardAbilities() {
+        this.eventRegistrar = new EventRegistrar(this.game, this);
+        this.eventRegistrar.register([
+            {
+                [EventNames.OnResolveRingElement + ':' + AbilityTypes.WouldInterrupt]: 'cancelRingEffect'
+            }
+        ]);
+
+        this.action({
+            title: 'Move holding to another province',
+            target: {
+                location: Locations.Provinces,
+                cardType: CardTypes.Province,
+                controller: Players.Self,
+                cardCondition: (card, context) =>
+                    card.location !== context.source.location && card.location !== Locations.StrongholdProvince
+            },
+            gameAction: AbilityDsl.actions.moveCard((context) => ({
+                target: context.source,
+                destination: context.target.location
+            })),
+            then: {
+                gameAction: AbilityDsl.actions.discardCard((context) => ({
+                    target: this.otherHoldingsInSameProvince(context)
+                })),
+                message: 'The {1} {3}',
+                messageArgs: (context) => [
+                    this.otherHoldingsInSameProvince(context).length > 0
+                        ? 'is angry and discards the holdings that they find in the province'
+                        : 'calms down'
+                ]
+            }
+        });
+    }
+
+    otherHoldingsInSameProvince(context) {
+        return context.game.allCards.filter(
+            (card) =>
+                card.location === context.source.location &&
+                card.type === CardTypes.Holding &&
+                !card.facedown &&
+                card !== context.source
+        );
+    }
+
+    cancelRingEffect(event) {
+        if(event.context.game.currentConflict && this.isInConflictProvince() && !event.cancelled) {
+            event.cancel();
+            this.game.addMessage('{0} cancels the ring effect', this);
+        }
+    }
+}
+
+StormFromSakkaku.id = 'storm-from-sakkaku';
+
+module.exports = StormFromSakkaku;

--- a/server/game/cards/19.1-AS01/Dragon/BambooTattoo.js
+++ b/server/game/cards/19.1-AS01/Dragon/BambooTattoo.js
@@ -1,0 +1,57 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, Locations, Players } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class BambooTattoo extends DrawCard {
+    setupCardAbilities() {
+        this.attachmentConditions({ myControl: true, trait: 'monk' });
+
+        this.whileAttached({ effect: AbilityDsl.effects.addTrait('tattooed') });
+
+        this.persistentEffect({
+            location: Locations.Any,
+            targetController: Players.Any,
+            effect: AbilityDsl.effects.reduceCost({
+                amount: 1,
+                targetCondition: (target) => target.type === CardTypes.Character && target.printedCost <= 3,
+                match: (card, source) => card === source
+            })
+        });
+
+        this.reaction({
+            title: 'Ready attached character',
+            when: {
+                onCardBowed: (event, context) =>
+                    context.source.parent &&
+                    event.card === context.source.parent &&
+                    event.context.source.type !== 'ring' &&
+                    event.context.source.name !== 'Framework effect'
+            },
+            gameAction: AbilityDsl.actions.multiple([
+                AbilityDsl.actions.ready((context) => ({ target: context.source.parent })),
+                AbilityDsl.actions.conditional({
+                    condition: (context) => this._bambooTattooSelfTrigger(context),
+                    trueGameAction: AbilityDsl.actions.dishonor((context) => ({ target: context.source.parent })),
+                    falseGameAction: AbilityDsl.actions.noAction()
+                })
+            ]),
+            effect: 'ready{1} {2}',
+            effectArgs: (context) => [
+                this._bambooTattooSelfTrigger(context) ? ' and dishonor' : '',
+                context.source.parent
+            ]
+        });
+    }
+
+    _bambooTattooSelfTrigger(context) {
+        return (
+            context.source.controller &&
+            context.event.context.player &&
+            context.source.controller === context.event.context.player
+        );
+    }
+}
+
+BambooTattoo.id = 'bamboo-tattoo';
+
+module.exports = BambooTattoo;

--- a/server/game/cards/19.1-AS01/Dragon/CliffsOftheSeaDragon.js
+++ b/server/game/cards/19.1-AS01/Dragon/CliffsOftheSeaDragon.js
@@ -1,0 +1,23 @@
+const { Players } = require('../../../Constants');
+const ProvinceCard = require('../../../provincecard.js');
+
+class CliffsOfTheSeaDragon extends ProvinceCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: Players.Opponent,
+            condition: (context) =>
+                !context.game.conflictRecord.some((conflict) => this.cliffsTurnOffCondition(context, conflict)),
+            effect: ability.effects.playerCannot('takeFateFromRings')
+        });
+    }
+
+    cliffsTurnOffCondition(context, conflict) {
+        let lostByDragon = conflict.winner === context.source.controller.opponent;
+        let passedByAnyone = conflict.passed;
+        return lostByDragon || passedByAnyone;
+    }
+}
+
+CliffsOfTheSeaDragon.id = 'cliffs-of-the-sea-dragon';
+
+module.exports = CliffsOfTheSeaDragon;

--- a/server/game/cards/19.1-AS01/Dragon/KitsukiMasanori.js
+++ b/server/game/cards/19.1-AS01/Dragon/KitsukiMasanori.js
@@ -1,0 +1,91 @@
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Decks, Durations } = require('../../../Constants');
+const DrawCard = require('../../../drawcard.js');
+
+const choice = {
+    discardPile: 'Search discard pile',
+    conflictDeck: 'Search conflict deck'
+};
+
+const selectAttachmentPrompt = 'Select an attachment';
+
+const attachMsg = '{0} takes {1} and attaches it to {2}';
+
+function matchesSearchableCard(card, context) {
+    return (
+        card.type === CardTypes.Attachment &&
+        (card.hasTrait('title') || card.hasTrait('technique')) &&
+        card.canAttach(context.source)
+    );
+}
+
+class KitsukiMasanori extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            effect: AbilityDsl.effects.cardCannot({ cannot: 'applyCovert', restricts: 'opponentsCardEffects' })
+        });
+
+        this.reaction({
+            title: 'Search for a Title or Technique',
+            when: { onCharacterEntersPlay: (event, context) => event.card === context.source },
+            effect: 'search for a Technique or Title',
+            gameAction: AbilityDsl.actions.sequential([
+                AbilityDsl.actions.chooseAction({
+                    activePromptTitle: 'Select where to search',
+                    choices: {
+                        [choice.discardPile]: AbilityDsl.actions.cardMenu((context) => ({
+                            activePromptTitle: selectAttachmentPrompt,
+                            cards: context.player.conflictDiscardPile.filter((card) =>
+                                matchesSearchableCard(card, context)
+                            ),
+                            subActionProperties: (card) => ({ attachment: card, target: context.source, bisteca: 33 }),
+                            gameAction: AbilityDsl.actions.attach(),
+                            message: '{0} takes {1} and attaches it to {2}',
+                            messageArgs: (card) => [context.source.controller, card, context.source]
+                        })),
+                        [choice.conflictDeck]: AbilityDsl.actions.deckSearch({
+                            activePromptTitle: selectAttachmentPrompt,
+                            deck: Decks.ConflictDeck,
+                            reveal: true,
+                            cardCondition: (card, context) => matchesSearchableCard(card, context),
+                            selectedCardsHandler: (context, event, cards) => {
+                                const card = cards[0];
+                                if(!card) {
+                                    return;
+                                }
+
+                                context.game.addMessage(attachMsg, event.player, card, context.source);
+                                context.game.queueSimpleStep(() =>
+                                    AbilityDsl.actions
+                                        .attach({ target: context.source, attachment: card })
+                                        .resolve(null, context)
+                                );
+                            }
+                        })
+                    },
+                    messages: {
+                        [choice.discardPile]: '{0} searches their discard pile',
+                        [choice.conflictDeck]: '{0} searches their conflict deck'
+                    }
+                }),
+                AbilityDsl.actions.cardLastingEffect((context) => {
+                    const fetchedAttachment = context.source.attachments.first();
+                    return {
+                        target: fetchedAttachment,
+                        condition: (context) => fetchedAttachment.parent === context.source,
+                        duration: Durations.Custom,
+                        effect: AbilityDsl.effects.cardCannot({
+                            cannot: 'target',
+                            restricts: 'opponentsCardAbilities',
+                            applyingPlayer: context.player
+                        })
+                    };
+                })
+            ])
+        });
+    }
+}
+
+KitsukiMasanori.id = 'kitsuki-masanori';
+
+module.exports = KitsukiMasanori;

--- a/server/game/cards/19.1-AS01/Dragon/KitsukiSeiji.js
+++ b/server/game/cards/19.1-AS01/Dragon/KitsukiSeiji.js
@@ -1,0 +1,84 @@
+const DrawCard = require('../../../drawcard.js');
+const { Elements } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+const elementKey = 'kitsuki-seiji-water';
+
+class KitsukiSeiji extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            condition: (context) => context.player.showBid % 2 === 1,
+            effect: [AbilityDsl.effects.modifyMilitarySkill(+2), AbilityDsl.effects.modifyPoliticalSkill(-2)]
+        });
+        this.persistentEffect({
+            condition: (context) => context.player.showBid % 2 === 0,
+            effect: [AbilityDsl.effects.modifyMilitarySkill(-2), AbilityDsl.effects.modifyPoliticalSkill(+2)]
+        });
+
+        this.wouldInterrupt({
+            title: 'Put fate on this character',
+            when: {
+                onMoveFate: (event) => this.fateRecipientIsSeijisRing(event.recipient),
+                onPlaceFateOnUnclaimedRings: (event) =>
+                    event.recipients.some((recipient) => this.fateRecipientIsSeijisRing(recipient.ring))
+            },
+            effect: 'put the fate that would go on the {1} ring on {0} instead',
+            effectArgs: () => [this.getCurrentElementSymbol(elementKey)],
+            gameAction: AbilityDsl.actions.cancel((context) => {
+                switch(context.event.name) {
+                    case 'onPlaceFateOnUnclaimedRings':
+                        return { replacementGameAction: this.replacementForPlaceFateOnUnclaimedRings(context) };
+                    case 'onMoveFate':
+                        return { replacementGameAction: this.replacementForMoveFate(context) };
+                    default:
+                        return { replacementGameAction: AbilityDsl.actions.noAction() };
+                }
+            })
+        });
+    }
+
+    getPrintedElementSymbols() {
+        let symbols = super.getPrintedElementSymbols();
+        symbols.push({
+            key: elementKey,
+            prettyName: 'Ring',
+            element: Elements.Water
+        });
+        return symbols;
+    }
+
+    fateRecipientIsSeijisRing(recipient) {
+        return recipient && recipient.type === 'ring' && recipient.hasElement(this.getCurrentElementSymbol(elementKey));
+    }
+
+    replacementForMoveFate(context) {
+        return AbilityDsl.actions.placeFate({
+            origin: context.event.origin,
+            target: context.source,
+            amount: context.event.fate
+        });
+    }
+
+    replacementForPlaceFateOnUnclaimedRings(context) {
+        return AbilityDsl.actions.joint(
+            context.event.recipients.map((recipient) => {
+                let isSeijisRing = recipient.ring.hasElement(this.getCurrentElementSymbol(elementKey));
+                if(isSeijisRing) {
+                    return AbilityDsl.actions.placeFate({
+                        target: context.source,
+                        amount: recipient.amount
+                    });
+                }
+                return AbilityDsl.actions.placeFateOnRing({
+                    amount: recipient.amount,
+                    target: recipient.ring
+                });
+
+            })
+        );
+    }
+}
+
+KitsukiSeiji.id = 'kitsuki-seiji';
+
+module.exports = KitsukiSeiji;

--- a/server/game/cards/19.1-AS01/Dragon/MasterOfTheBlade.js
+++ b/server/game/cards/19.1-AS01/Dragon/MasterOfTheBlade.js
@@ -1,0 +1,63 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, DuelTypes, Players } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class MasterOfTheBlade extends DrawCard {
+    setupCardAbilities() {
+        const sacCondition = (card, context) => card.allowGameAction('sacrifice', context) && !card.bowed && card.hasTrait('weapon');
+
+        this.action({
+            condition: (context) =>
+                context.source.isParticipating() && !context.source.bowed,
+            limit: AbilityDsl.limit.perRound(2),
+            cost: AbilityDsl.costs.bow({
+                cardType: CardTypes.Attachment,
+                cardCondition: (card, context) => card.parent === context.source && card.hasTrait('weapon')
+            }),
+            title: 'Initiate a military duel',
+            initiateDuel: context => ({
+                type: DuelTypes.Military,
+                message: '{0} {1}',
+                messageArgs: duel => (duel.winner === context.source && context.source.attachments.filter(card => sacCondition(card, context)).length > 0) ?
+                    ['bow or discard', duel.loser] : ['bow', duel.loser],
+                gameAction: duel => {
+                    const wonDuel = duel.winner === context.source;
+                    const canSacWeapon = context.source.attachments.filter(card => sacCondition(card, context)).length > 0;
+                    if(!wonDuel || !canSacWeapon) {
+                        return AbilityDsl.actions.bow({ target: duel.loser });
+                    }
+
+                    return AbilityDsl.actions.chooseAction({
+                        messages: {
+                            'Sacrifice a weapon to discard loser': '{0} chooses to sacrifice a weapon to discard {2}',
+                            'Bow loser': '{0} chooses to bow {2}'
+                        },
+                        messageArgs: [duel.loser],
+                        choices: {
+                            'Sacrifice a weapon to discard loser': AbilityDsl.actions.multiple([
+                                AbilityDsl.actions.selectCard(context => ({
+                                    controller: Players.Self,
+                                    cardCondition: card => card.parent && card.parent === context.source && sacCondition(card, context),
+                                    message: '{0} sacrifices {1}',
+                                    messageArgs: card => [context.player, card],
+                                    gameAction: AbilityDsl.actions.sacrifice()
+                                })),
+                                AbilityDsl.actions.discardFromPlay({ target: duel.loser })
+                            ]),
+                            'Bow loser': AbilityDsl.actions.multiple([
+                                AbilityDsl.actions.bow({ target: duel.loser }),
+                                AbilityDsl.actions.handler({
+                                    handler: () => true
+                                })
+                            ])
+                        }
+                    });
+                }
+            })
+        });
+    }
+}
+
+MasterOfTheBlade.id = 'master-of-the-blade';
+
+module.exports = MasterOfTheBlade;

--- a/server/game/cards/19.1-AS01/Dragon/NamelessBrother.js
+++ b/server/game/cards/19.1-AS01/Dragon/NamelessBrother.js
@@ -1,0 +1,26 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl.js');
+const { CardTypes } = require('../../../Constants.js');
+
+class NamelessBrother extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            match: (card, context) =>
+                card.controller === context.player &&
+                card.type === CardTypes.Character,
+            effect: AbilityDsl.effects.modifyBothSkills(
+                (character, context) =>
+                    context.player.cardsInPlay.filter(
+                        (otherCard) =>
+                            otherCard.name === character.name &&
+                            otherCard.uuid !== character.uuid &&
+                            otherCard.type === CardTypes.Character
+                    ).length
+            )
+        });
+    }
+}
+
+NamelessBrother.id = 'nameless-brother';
+
+module.exports = NamelessBrother;

--- a/server/game/cards/19.1-AS01/Dragon/PalmStrike.js
+++ b/server/game/cards/19.1-AS01/Dragon/PalmStrike.js
@@ -1,0 +1,64 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { Players, Durations, CardTypes } = require('../../../Constants');
+
+class PalmStrike extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Bow a character',
+            targets: {
+                myMonk: {
+                    activePromptTitle: 'Choose a bare-handed monk',
+                    cardType: CardTypes.Character,
+                    controller: Players.Self,
+                    cardCondition: (monkCharacter) =>
+                        monkCharacter.isParticipating() &&
+                        monkCharacter.hasTrait('monk') &&
+                        this.cardHasNoWeaponAttachments(monkCharacter)
+                },
+                characterToBow: {
+                    dependsOn: 'myMonk',
+                    activePromptTitle: 'Choose a character to bow',
+                    cardType: CardTypes.Character,
+                    controller: Players.Opponent,
+                    cardCondition: (opponentCharacter) =>
+                        opponentCharacter.isParticipating() &&
+                        this.cardHasNoWeaponAttachments(opponentCharacter),
+                    gameAction: AbilityDsl.actions.multiple([
+                        AbilityDsl.actions.bow(),
+                        AbilityDsl.actions.conditional({
+                            condition: (context) => context.targets.myMonk && context.targets.myMonk.hasTrait('tattooed'),
+                            falseGameAction: AbilityDsl.actions.noAction(),
+                            trueGameAction:
+                                AbilityDsl.actions.cardLastingEffect({
+                                    effect: AbilityDsl.effects.cardCannot({
+                                        cannot: 'ready'
+                                    }),
+                                    duration: Durations.UntilEndOfConflict
+                                })
+                        })
+                    ])
+                }
+            },
+            effect: 'bow {1} — they are {2}{3}{4}.',
+            effectArgs: (context) => [
+                context.targets.characterToBow,
+                context.targets.myMonk.hasTrait('tattooed')
+                    ? 'overwhelmed by the mystical tattoos of'
+                    : 'stricken down by',
+                context.targets.myMonk.isUnique() ? ' ' : ' the ',
+                context.targets.myMonk
+            ]
+        });
+    }
+
+    cardHasNoWeaponAttachments(card) {
+        return !card.attachments.any((attachment) =>
+            attachment.hasTrait('weapon')
+        );
+    }
+}
+
+PalmStrike.id = 'palm-strike';
+
+module.exports = PalmStrike;

--- a/server/game/cards/19.1-AS01/Dragon/SeijisFate.js
+++ b/server/game/cards/19.1-AS01/Dragon/SeijisFate.js
@@ -1,0 +1,19 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+
+class SeijisFate extends DrawCard {
+    setupCardAbilities() {
+        this.whileAttached({
+            effect: [
+                AbilityDsl.effects.addTrait('creature'),
+                AbilityDsl.effects.loseTrait('bushi'),
+                AbilityDsl.effects.loseTrait('courtier'),
+                AbilityDsl.effects.blank()
+            ]
+        });
+    }
+}
+
+SeijisFate.id = 'seiji-s-fate';
+
+module.exports = SeijisFate;

--- a/server/game/cards/19.1-AS01/Dragon/VillageDoshin.js
+++ b/server/game/cards/19.1-AS01/Dragon/VillageDoshin.js
@@ -1,0 +1,66 @@
+const DrawCard = require('../../../drawcard.js');
+const { Locations, CardTypes, Players } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+const DOSHIN_TAX = 2;
+
+class VillageDoshin extends DrawCard {
+    setupCardAbilities() {
+        this.wouldInterrupt({
+            title: 'Protect attachment from leaving play',
+            location: Locations.Hand,
+            cost: AbilityDsl.costs.discardSelf(),
+            when: {
+                onInitiateAbilityEffects: (event, context) =>
+                    event.cardTargets.some((card) => {
+                        let attachment = card.type === CardTypes.Attachment;
+                        let onCharacterYouControl =
+                            card.parent &&
+                            card.parent.type === CardTypes.Character &&
+                            card.parent.controller === context.player;
+                        let inPlay = card.location === Locations.PlayArea;
+                        return attachment && onCharacterYouControl && inPlay;
+                    })
+            },
+
+            gameAction: AbilityDsl.actions.conditional({
+                condition: (context) => {
+                    let opponentHasEnoughCards = context.player.opponent.hand.size() >= DOSHIN_TAX;
+                    let opponentIsAllowedToDiscardCards = AbilityDsl.actions
+                        .discardAtRandom({ amount: 2 })
+                        .canAffect(context.player.opponent, context);
+                    return opponentHasEnoughCards && opponentIsAllowedToDiscardCards;
+                },
+                falseGameAction: AbilityDsl.actions.cancel(),
+                trueGameAction: AbilityDsl.actions.chooseAction((context) => {
+                    let payOption = 'Discard ' + DOSHIN_TAX + ' random cards from hand';
+                    let refuseOption = 'Let the effect be canceled';
+                    return {
+                        player: Players.Opponent,
+                        activePromptTitle: 'Select one',
+                        choices: {
+                            [payOption]: AbilityDsl.actions.discardAtRandom({
+                                amount: DOSHIN_TAX,
+                                target: context.player.opponent
+                            }),
+                            [refuseOption]: AbilityDsl.actions.cancel()
+                        },
+                        messages: {
+                            [payOption]: '{0} distracts the Dōshin.',
+                            [refuseOption]:
+                                '{0} refuses to discard ' + DOSHIN_TAX + ' cards. The effects of {2} are canceled.'
+                        },
+                        messageArgs: [context.event.card]
+                    };
+                })
+            }),
+
+            effect: 'protect {1}',
+            effectArgs: (context) => context.event.cardTargets
+        });
+    }
+}
+
+VillageDoshin.id = 'village-doshin';
+
+module.exports = VillageDoshin;

--- a/server/game/cards/19.1-AS01/Lion/CornerThePrey.js
+++ b/server/game/cards/19.1-AS01/Lion/CornerThePrey.js
@@ -1,0 +1,37 @@
+const DrawCard = require('../../../drawcard.js');
+const { ConflictTypes, TargetModes, CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class CornerThePrey extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Sacrifice followers to kill',
+            condition: context => context.game.isDuringConflict(ConflictTypes.Military),
+            cost: AbilityDsl.costs.sacrifice({
+                cardType: [CardTypes.Character, CardTypes.Attachment],
+                mode: TargetModes.Unlimited,
+                cardCondition: card => card.hasTrait('follower') && (card.isParticipating() || (card.parent && card.parent.isParticipating()))
+            }),
+            target: {
+                cardType: CardTypes.Character,
+                cardCondition: (card, context) => card.isParticipating() && card.printedCost <= this.getFollowerCount(context),
+                gameAction: AbilityDsl.actions.discardFromPlay()
+            },
+            cannotTargetFirst: true
+        });
+    }
+
+    getFollowerCount(context) {
+        if(context.costs.sacrifice) {
+            return context.costs.sacrifice.length;
+        }
+        const myFollowers = context.game.allCards.filter(card => card.controller === context.player && card.hasTrait('follower'));
+        const myParticipatingFollowers = myFollowers.filter(card => card.isParticipating() || (card.parent && card.parent.isParticipating()));
+        const amount = myParticipatingFollowers.length;
+        return amount;
+    }
+}
+
+CornerThePrey.id = 'corner-the-prey';
+
+module.exports = CornerThePrey;

--- a/server/game/cards/19.1-AS01/Lion/FortunesField.js
+++ b/server/game/cards/19.1-AS01/Lion/FortunesField.js
@@ -1,0 +1,24 @@
+const { Durations, CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+const ProvinceCard = require('../../../provincecard.js');
+
+class FortunesField extends ProvinceCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardPlayed: (event, context) => event.player === context.player && event.card.type === CardTypes.Character
+            },
+            title: 'Reduce cost of next character or follower by 1',
+            effect: 'reduce the cost of their next character or follower this round by 1',
+            gameAction: AbilityDsl.actions.playerLastingEffect(context => ({
+                targetController: context.player,
+                duration: Durations.UntilEndOfRound,
+                effect: AbilityDsl.effects.reduceNextPlayedCardCost(1, card => card.type === CardTypes.Character || card.hasTrait('follower'))
+            }))
+        });
+    }
+}
+
+FortunesField.id = 'fortune-s-field';
+
+module.exports = FortunesField;

--- a/server/game/cards/19.1-AS01/Lion/IkomaMasterHunter.js
+++ b/server/game/cards/19.1-AS01/Lion/IkomaMasterHunter.js
@@ -1,0 +1,44 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, Players, TargetModes, Phases, Durations } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class IkomaMasterHunter extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'move in and ready when target joins',
+            when: {
+                onPhaseStarted: (event) => event.phase === Phases.Conflict
+            },
+            target: {
+                mode: TargetModes.Single,
+                controller: Players.Opponent,
+                cardType: CardTypes.Character,
+                gameAction: AbilityDsl.actions.cardLastingEffect(context => ({
+                    duration: Durations.UntilEndOfPhase,
+                    target: context.source,
+                    effect: AbilityDsl.effects.delayedEffect({
+                        when: {
+                            onMoveToConflict: event => event.card === context.target,
+                            onDefendersDeclared: event => event.conflict.getParticipants().includes(context.target),
+                            onConflictDeclared: event => event.conflict.getParticipants().includes(context.target)
+                        },
+                        multipleTrigger: true,
+                        gameAction: AbilityDsl.actions.multiple([
+                            AbilityDsl.actions.moveToConflict({
+                                target: context.source
+                            }),
+                            AbilityDsl.actions.ready({
+                                target: context.source
+                            })
+                        ])
+                    })
+                }))
+            },
+            effect: 'track {0}'
+        });
+    }
+}
+
+IkomaMasterHunter.id = 'ikoma-master-hunter';
+
+module.exports = IkomaMasterHunter;

--- a/server/game/cards/19.1-AS01/Lion/Kinki.js
+++ b/server/game/cards/19.1-AS01/Lion/Kinki.js
@@ -1,0 +1,37 @@
+const DrawCard = require('../../../drawcard.js');
+const { Players, TargetModes, CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class Kinki extends DrawCard {
+    setupCardAbilities() {
+        this.attachmentConditions({
+            myControl: true
+        });
+
+        this.action({
+            title: 'Remove a fate from or move home a character',
+            cost: AbilityDsl.costs.sacrificeSelf(),
+            condition: context => context.game.isDuringConflict('military') && context.source.parent && context.source.parent.isParticipating(),
+            targets: {
+                character: {
+                    cardType: CardTypes.Character,
+                    controller: Players.Opponent,
+                    cardCondition: card => card.isParticipating()
+                },
+                select: {
+                    mode: TargetModes.Select,
+                    dependsOn: 'character',
+                    player: Players.Opponent,
+                    choices: {
+                        'Remove a fate from this character': AbilityDsl.actions.removeFate(context => ({ target: context.targets.character })),
+                        'Move this character home': AbilityDsl.actions.sendHome(context => ({ target: context.targets.character }))
+                    }
+                }
+            }
+        });
+    }
+}
+
+Kinki.id = 'kinki';
+
+module.exports = Kinki;

--- a/server/game/cards/19.1-AS01/Lion/PlantedFields.js
+++ b/server/game/cards/19.1-AS01/Lion/PlantedFields.js
@@ -1,0 +1,30 @@
+const AbilityDsl = require('../../../abilitydsl');
+const DrawCard = require('../../../drawcard.js');
+const { Phases } = require('../../../Constants');
+
+class PlantedFields extends DrawCard {
+    setupCardAbilities() {
+        this.interrupt({
+            title: 'Gain 1 fate, gain 1 honor and draw 1 card',
+            when : {
+                onPhaseEnded: (event, context) => event.phase === Phases.Conflict && !context.player.getProvinceCardInProvince(context.source.location).isBroken
+            },
+            cost: AbilityDsl.costs.sacrificeSelf(),
+            gameAction: AbilityDsl.actions.sequential([
+                AbilityDsl.actions.gainFate(context => ({
+                    target: context.player,
+                    amount: 2
+                })),
+                AbilityDsl.actions.draw(context => ({
+                    target: context.player,
+                    amount: 2
+                }))
+            ]),
+            effect: 'gain 2 fate and draw 2 cards'
+        });
+    }
+}
+
+PlantedFields.id = 'planted-fields';
+
+module.exports = PlantedFields;

--- a/server/game/cards/19.1-AS01/Lion/PromisingHohei.js
+++ b/server/game/cards/19.1-AS01/Lion/PromisingHohei.js
@@ -1,0 +1,34 @@
+const DrawCard = require('../../../drawcard.js');
+const { Players, TargetModes, Locations, CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class PromisingHohei extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            location: Locations.Any,
+            targetController: Players.Any,
+            effect: AbilityDsl.effects.reduceCost({
+                amount: 1,
+                targetCondition: (target) => target.type === CardTypes.Character && target.getGlory() >= 2,
+                match: (card, source) => card === source
+            })
+        });
+
+        this.reaction({
+            title: 'return a follower to hand',
+            when: {
+                onCardAttached: (event, context) => event.card === context.source
+            },
+            target: {
+                mode: TargetModes.Single,
+                controller: Players.Self,
+                cardCondition: (card) => card.name !== 'Promising Hohei' && card.hasTrait('follower'),
+                gameAction: AbilityDsl.actions.returnToHand()
+            }
+        });
+    }
+}
+
+PromisingHohei.id = 'promising-hohei';
+
+module.exports = PromisingHohei;

--- a/server/game/cards/19.1-AS01/Lion/RelentlessGloryseeker.js
+++ b/server/game/cards/19.1-AS01/Lion/RelentlessGloryseeker.js
@@ -1,0 +1,56 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { EventNames, Locations, Phases } = require('../../../Constants.js');
+const EventRegistrar = require('../../../eventregistrar.js');
+
+const MAXIMUM_RESSURRECTIONS = 1;
+
+class RelentlessGloryseeker extends DrawCard {
+    setupCardAbilities() {
+        this.ressurrectionsThisRound = 0;
+        this.eventRegistrar = new EventRegistrar(this.game, this);
+        this.eventRegistrar.register([
+            EventNames.OnRoundEnded,
+            EventNames.OnCardLeavesPlay
+        ]);
+
+        this.reaction({
+            title: 'Put this character into play',
+            location: Locations.DynastyDiscardPile,
+            when: {
+                onCardLeavesPlay: (event, context) =>
+                    event.card === context.source &&
+                    context.game.currentPhase === Phases.Conflict &&
+                    this.ressurrectionsThisRound < MAXIMUM_RESSURRECTIONS
+            },
+            gameAction: AbilityDsl.actions.putIntoPlay(),
+            effect: 'return to play - {0} is ready for more!',
+            then: () => {
+                this.ressurrectionsThisRound++;
+                return { gameAction: AbilityDsl.actions.noAction() };
+            }
+        });
+    }
+
+    onRoundEnded() {
+        this.ressurrectionsThisRound = 0;
+    }
+
+    onCardLeavesPlay(event) {
+        if(
+            event.card === this &&
+            this.location !== Locations.RemovedFromGame &&
+            this.ressurrectionsThisRound >= MAXIMUM_RESSURRECTIONS
+        ) {
+            this.game.addMessage(
+                '{0} is removed from the game due to leaving play - may their tales lead them to Yomi',
+                this
+            );
+            this.owner.moveCard(this, Locations.RemovedFromGame);
+        }
+    }
+}
+
+RelentlessGloryseeker.id = 'relentless-gloryseeker';
+
+module.exports = RelentlessGloryseeker;

--- a/server/game/cards/19.1-AS01/Lion/TheLionsShadow.js
+++ b/server/game/cards/19.1-AS01/Lion/TheLionsShadow.js
@@ -1,0 +1,33 @@
+const DrawCard = require('../../../drawcard.js');
+const { Phases } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class TheLionsShadow extends DrawCard {
+    setupCardAbilities() {
+        this.attachmentConditions({
+            limitTrait: { title: 1 },
+            trait: ['courtier', 'scout']
+        });
+
+        this.persistentEffect({
+            condition: (context) => context.game.currentPhase === Phases.Fate,
+            effect: AbilityDsl.effects.addKeyword('ancestral')
+        });
+
+        this.whileAttached({
+            condition: (context) => context.source.parent.isDishonored,
+            effect: AbilityDsl.effects.honorStatusDoesNotModifySkill()
+        });
+
+        this.whileAttached({
+            condition: (context) =>
+                context.source.parent.isAttacking() &&
+                context.game.currentConflict.getNumberOfParticipantsFor('attacker') === 1,
+            effect: AbilityDsl.effects.addKeyword('covert')
+        });
+    }
+}
+
+TheLionsShadow.id = 'the-lion-s-shadow';
+
+module.exports = TheLionsShadow;

--- a/server/game/cards/19.1-AS01/Neutral/ForcedRetirement.js
+++ b/server/game/cards/19.1-AS01/Neutral/ForcedRetirement.js
@@ -1,0 +1,54 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { Players, CardTypes, CharacterStatus } = require('../../../Constants');
+
+class ForcedRetirement extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Remove negative status tokens from a character, and discard it from play',
+            effect: 'expiate {0}\'s misdeeds by retiring them to the nearest monatery{1} Let them contemplate their sins.',
+            effectArgs: (context) => [
+                context.target.fate > 0 ? ', recovering their ' + context.target.fate + ' fate.' : '.'
+            ],
+            target: {
+                cardType: CardTypes.Character,
+                controller: Players.Self,
+                cardCondition: (card) => (card.isDishonored || card.isTainted) && !card.isParticipating()
+            },
+            gameAction: AbilityDsl.actions.sequentialContext((context) => ({
+                gameActions: [
+                    AbilityDsl.actions.multiple([
+                        AbilityDsl.actions.discardStatusToken({
+                            target: [context.target.statusTokens.filter((t) => this._isAffectedToken(t))]
+                        }),
+                        AbilityDsl.actions.removeFate({
+                            target: context.target,
+                            amount: context.target.getFate(),
+                            recipient: context.target.owner
+                        })
+                    ]),
+                    AbilityDsl.actions.multiple([
+                        AbilityDsl.actions.discardFromPlay({
+                            target: context.target
+                        }),
+                        AbilityDsl.actions.gainHonor({
+                            target: context.player,
+                            amount: 1
+                        })
+                    ])
+                ]
+            }))
+        });
+    }
+
+    _isAffectedToken(statusToken) {
+        return (
+            statusToken.grantedStatus === CharacterStatus.Dishonored ||
+            statusToken.grantedStatus === CharacterStatus.Tainted
+        );
+    }
+}
+
+ForcedRetirement.id = 'forced-retirement';
+
+module.exports = ForcedRetirement;

--- a/server/game/cards/19.1-AS01/Neutral/JealousAncestor.js
+++ b/server/game/cards/19.1-AS01/Neutral/JealousAncestor.js
@@ -1,0 +1,74 @@
+const DrawCard = require('../../../drawcard.js');
+const PlayAttachmentAction = require('../../../playattachmentaction.js');
+const { CardTypes, Durations, Players, Elements } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+const elementKey = 'jealous-ancestor-void';
+
+class PlayAsAttachment extends PlayAttachmentAction {
+    constructor(card) {
+        super(card, true);
+        this.title = 'Play Jealous Ancestor as an attachment';
+    }
+
+    executeHandler(context) {
+        AbilityDsl.actions
+            .cardLastingEffect({
+                duration: Durations.Custom,
+                canChangeZoneOnce: true,
+                effect: AbilityDsl.effects.changeType(CardTypes.Attachment)
+            })
+            .resolve(this.card, context);
+        super.executeHandler(context);
+    }
+}
+
+class JealousAncestor extends DrawCard {
+    setupCardAbilities() {
+        this.abilities.playActions.push(new PlayAsAttachment(this));
+
+        this.whileAttached({ effect: AbilityDsl.effects.addTrait('haunted') });
+        this.persistentEffect({
+            condition: (context) => context.source.parent,
+            effect: AbilityDsl.effects.immunity({ restricts: 'events' })
+        });
+
+        this.addAttachedEffectOnOpponent(
+            AbilityDsl.effects.playerCannot({ cannot: 'draw', restricts: 'opponentsCardEffects' })
+        );
+        this.addAttachedEffectOnOpponent(AbilityDsl.effects.playerCannot({ cannot: 'move', restricts: 'toHand' }));
+        this.addAttachedEffectOnOpponent(AbilityDsl.effects.playerCannot({ cannot: 'returnToHand' }));
+    }
+
+    leavesPlay() {
+        this.printedType = CardTypes.Character;
+        super.leavesPlay();
+    }
+
+    getPrintedElementSymbols() {
+        let symbols = super.getPrintedElementSymbols();
+        symbols.push({
+            key: elementKey,
+            prettyName: 'Claimed Ring',
+            element: Elements.Void
+        });
+        return symbols;
+    }
+
+    addAttachedEffectOnOpponent(effect) {
+        this.persistentEffect({
+            condition: (context) =>
+                context.source.parent &&
+                context.source.parent.isParticipating() &&
+                !this.game.rings[this.getCurrentElementSymbol(elementKey)].isConsideredClaimed(
+                    context.source.parent.controller
+                ),
+            targetController: Players.Opponent,
+            effect: effect
+        });
+    }
+}
+
+JealousAncestor.id = 'jealous-ancestor';
+
+module.exports = JealousAncestor;

--- a/server/game/cards/19.1-AS01/Neutral/Kuro.js
+++ b/server/game/cards/19.1-AS01/Neutral/Kuro.js
@@ -1,0 +1,56 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { Locations, Players, CardTypes, TargetModes } = require('../../../Constants.js');
+
+class Kuro extends DrawCard {
+    allowAttachment(attachment) {
+        if(attachment.printedCost < 1) {
+            return false;
+        }
+        return super.allowAttachment(attachment);
+    }
+
+    setupCardAbilities() {
+        this.action({
+            title: 'Play opponent discarded attachment',
+            condition: context => context.game.isDuringConflict(),
+            target: {
+                location: Locations.ConflictDiscardPile,
+                controller: Players.Opponent,
+                cardType: CardTypes.Attachment,
+                mode: TargetModes.Single,
+                cardCondition: card => card.printedCost >= 1 && card.canAttach(this, {
+                    ignoreType: false,
+                    controller: this.controller
+                }),
+                gameAction: AbilityDsl.actions.sequential([
+                    AbilityDsl.actions.playerLastingEffect(context => ({
+                        targetController: context.player,
+                        effect: AbilityDsl.effects.reduceNextPlayedCardCost(1)
+                    })),
+                    AbilityDsl.actions.playCard(context => ({
+                        source: this,
+                        payCosts: true,
+                        target: context.target,
+                        optional: false,
+                        playCardTarget: attachContext => {
+                            attachContext.target = context.source;
+                            attachContext.targets.target = context.source;
+                        }
+                    })),
+                    AbilityDsl.actions.conditional(conditionalContext => ({
+                        condition: context => context.source.isParticipating(),
+                        trueGameAction: AbilityDsl.actions.sendHome({ target: conditionalContext.source }),
+                        falseGameAction: AbilityDsl.actions.moveToConflict({ target: conditionalContext.source })
+                    }))
+                ])
+            },
+            effect: 'seek the lost treasure \'{1}\'. {2}',
+            effectArgs: context => [context.target, context.source.isParticipating() ? 'Kuro returns home with their treasure' : 'Kuro swoops into the conflict']
+        });
+    }
+}
+
+Kuro.id = 'kuro';
+
+module.exports = Kuro;

--- a/server/game/cards/19.1-AS01/Neutral/MangroveSafehouse.js
+++ b/server/game/cards/19.1-AS01/Neutral/MangroveSafehouse.js
@@ -1,0 +1,48 @@
+const AbilityDsl = require('../../../abilitydsl.js');
+const { CardTypes, Players } = require('../../../Constants.js');
+const DrawCard = require('../../../drawcard.js');
+
+class MangroveSafehouse extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Move an attacker out of the conflict',
+            effect: 'move {0} home{1}',
+            effectArgs: (context) => [
+                this.targetIsMantis(context) && this.opponentHasFateToBeStolen(context) ? ' and steal 1 fate' : ''
+            ],
+            condition: (context) => context.game.isDuringConflict(),
+            target: {
+                cardType: CardTypes.Character,
+                controller: Players.Self,
+                cardCondition: (card) => card.isAttacking(),
+                gameAction: AbilityDsl.actions.multipleContext((context) => {
+                    if(this.targetIsMantis(context)) {
+                        return {
+                            gameActions: [
+                                AbilityDsl.actions.sendHome(),
+                                AbilityDsl.actions.takeFate({
+                                    target: context.player.opponent
+                                })
+                            ]
+                        };
+                    }
+                    return {
+                        gameActions: [AbilityDsl.actions.sendHome()]
+                    };
+                })
+            }
+        });
+    }
+
+    targetIsMantis(context) {
+        return context.target.traits.some((trait) => trait === 'mantis-clan');
+    }
+
+    opponentHasFateToBeStolen(context) {
+        return context.player.opponent.fate > 0;
+    }
+}
+
+MangroveSafehouse.id = 'mangrove-safehouse';
+
+module.exports = MangroveSafehouse;

--- a/server/game/cards/19.1-AS01/Neutral/MantisRaider.js
+++ b/server/game/cards/19.1-AS01/Neutral/MantisRaider.js
@@ -1,0 +1,36 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+
+class MantisRaider extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Steal a fate',
+            when: {
+                onConflictStarted: (event, context) =>
+                    context.source.isAttacking() &&
+                    event.conflict.defenders.length === 0
+            },
+            effect: 'take a fate from {1} and place it on {0}.',
+            effectArgs: (context) => context.player.opponent,
+            gameAction: AbilityDsl.actions.placeFate((context) => ({
+                origin: context.player.opponent
+            }))
+        });
+
+        this.action({
+            title: 'Give this character +1 military',
+            condition: () => this.game.isDuringConflict(),
+            cost: AbilityDsl.costs.removeFateFromSelf(),
+            effect: 'give himself +1{1}',
+            effectArgs: () => ['military'],
+            gameAction: AbilityDsl.actions.cardLastingEffect({
+                effect: AbilityDsl.effects.modifyMilitarySkill(1)
+            }),
+            limit: AbilityDsl.limit.perConflict(2)
+        });
+    }
+}
+
+MantisRaider.id = 'mantis-raider';
+
+module.exports = MantisRaider;

--- a/server/game/cards/19.1-AS01/Neutral/MarvelousBeings.js
+++ b/server/game/cards/19.1-AS01/Neutral/MarvelousBeings.js
@@ -1,0 +1,27 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { ConflictTypes, CardTypes, Durations } = require('../../../Constants.js');
+
+class MarvelousBeings extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Ready this character',
+            condition: context => context.game.isDuringConflict(ConflictTypes.Political),
+            cost: AbilityDsl.costs.moveToConflict({
+                cardCondition: card => (card.hasTrait('spirit') || card.hasTrait('creature')) && card.type === CardTypes.Character
+            }),
+            gameAction: AbilityDsl.actions.playerLastingEffect(context => ({
+                target: context.player,
+                duration: Durations.UntilEndOfConflict,
+                effect: AbilityDsl.effects.changePlayerSkillModifier(context.costs.moveToConflict ? context.costs.moveToConflict.printedCost : 0)
+            })),
+            effect: 'entrance the court, giving their side an extra {1}{2} this conflict',
+            effectArgs: context => [context.costs.moveToConflict.printedCost, 'political'],
+            max:AbilityDsl.limit.perConflict(1)
+        });
+    }
+}
+
+MarvelousBeings.id = 'marvelous-beings';
+
+module.exports = MarvelousBeings;

--- a/server/game/cards/19.1-AS01/Neutral/MischievousTanuki.js
+++ b/server/game/cards/19.1-AS01/Neutral/MischievousTanuki.js
@@ -1,0 +1,49 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { Phases } = require('../../../Constants.js');
+
+class MischievousTanuki extends DrawCard {
+    setupCardAbilities() {
+        this.legendary(0);
+
+        this.action({
+            title: 'Set honor dials',
+            phase: Phases.Conflict,
+            gameAction: AbilityDsl.actions.honorBid({
+                message: '{0}{1}{2}{3}',
+                messageArgs: context => {
+                    if(context.player.showBid % 2 === context.player.opponent.showBid % 2) {
+                        return [context.player, ' takes 2 fate from ', context.player.opponent, ''];
+                    } else if(context.player.showBid % 2 === 0) {
+                        return [context.player, ' gains 2 honor and ', context.player.opponent, ' draws 2 cards'];
+                    }
+                    return [context.player, ' draws 2 cards and ', context.player.opponent, ' gains 2 honor'];
+                },
+                postBidAction: AbilityDsl.actions.conditional({
+                    condition: context => {
+                        return context.player.showBid % 2 === context.player.opponent.showBid % 2;
+                    },
+                    trueGameAction: AbilityDsl.actions.takeFate(context => ({
+                        target: context.player.opponent,
+                        amount: 2
+                    })),
+                    falseGameAction: AbilityDsl.actions.multiple([
+                        AbilityDsl.actions.draw(context => ({
+                            target: context.player.showBid % 2 === 1 ? context.player : context.player.opponent,
+                            amount: 2
+                        })),
+                        AbilityDsl.actions.gainHonor(context => ({
+                            target: context.player.showBid % 2 === 0 ? context.player : context.player.opponent,
+                            amount: 2
+                        }))
+                    ])
+                })
+            }),
+            effect: 'play a game!'
+        });
+    }
+}
+
+MischievousTanuki.id = 'mischievous-tanuki';
+
+module.exports = MischievousTanuki;

--- a/server/game/cards/19.1-AS01/Neutral/OtterFisherman.js
+++ b/server/game/cards/19.1-AS01/Neutral/OtterFisherman.js
@@ -1,0 +1,55 @@
+const DrawCard = require('../../../drawcard.js');
+const { TargetModes, Players, Elements } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+const elementKey = 'otter-fisherman-water';
+
+class OtterFisherman extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            effect: [
+                AbilityDsl.effects.immunity({
+                    restricts: 'creature'
+                })]
+        }),
+        this.reaction({
+            title: 'Gain resource after claiming water',
+            when: {
+                onClaimRing: (event, context) => ((event.conflict && event.conflict.hasElement(this.getCurrentElementSymbol(elementKey))) || event.ring.hasElement(this.getCurrentElementSymbol(elementKey))) && event.player === context.player
+            },
+            target: {
+                mode: TargetModes.Select,
+                player: Players.Opponent,
+                activePromptTitle: 'Choose an option for your opponent',
+                choices: {
+                    'Opponent gains 1 fate': AbilityDsl.actions.gainFate(context => ({
+                        target: context.source.controller,
+                        amount: 1
+                    })),
+                    'Opponent gains 1 honor': AbilityDsl.actions.gainHonor(context => ({
+                        target: context.source.controller,
+                        amount: 1
+                    })),
+                    'Opponent draws 1 card': AbilityDsl.actions.draw(context => ({
+                        target: context.source.controller,
+                        amount: 1
+                    }))
+                }
+            }
+        });
+    }
+
+    getPrintedElementSymbols() {
+        let symbols = super.getPrintedElementSymbols();
+        symbols.push({
+            key: elementKey,
+            prettyName: 'Ring',
+            element: Elements.Water
+        });
+        return symbols;
+    }
+}
+
+OtterFisherman.id = 'otter-fisherman';
+
+module.exports = OtterFisherman;

--- a/server/game/cards/19.1-AS01/Neutral/ToConnectThePeople.js
+++ b/server/game/cards/19.1-AS01/Neutral/ToConnectThePeople.js
@@ -1,0 +1,85 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Locations, Players, TargetModes, PlayTypes } = require('../../../Constants.js');
+const PlayCharacterAction = require('../../../playcharacteraction.js');
+const PlayDisguisedCharacterAction = require('../../../PlayDisguisedCharacterAction.js');
+
+class ConnectThePeoplePlayAction extends PlayCharacterAction {
+    constructor(card) {
+        super(card, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location')
+            ? ignoredRequirements
+            : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+class ConnectThePeoplePlayDisguisedAction extends PlayDisguisedCharacterAction {
+    constructor(card) {
+        super(card, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location')
+            ? ignoredRequirements
+            : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+
+class ToConnectThePeople extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Play a character from your opponent\'s discard pile',
+            condition: (context) =>
+                !context.game.isDuringConflict() &&
+                context.player.cardsInPlay.any(
+                    (card) => card.getType() === CardTypes.Character && card.hasTrait('merchant')
+                ),
+            gameAction: AbilityDsl.actions.sequential([
+                AbilityDsl.actions.discardCard((context) => ({
+                    target: context.player.opponent && context.player.opponent.dynastyDeck.first(3)
+                })),
+
+                AbilityDsl.actions.selectCard({
+                    cardType: CardTypes.Character,
+                    controller: Players.Opponent,
+                    location: [Locations.ConflictDiscardPile, Locations.DynastyDiscardPile],
+                    targets: true,
+                    cardCondition: (card, context) =>
+                        !card.isUnique() &&
+                        context.player.cardsInPlay.some((cardInPlay) => cardInPlay.glory >= card.glory),
+                    mode: TargetModes.Single,
+                    gameAction: AbilityDsl.actions.sequential([
+                        AbilityDsl.actions.cardLastingEffect({
+                            effect: [
+                                AbilityDsl.effects.gainPlayAction(ConnectThePeoplePlayAction),
+                                AbilityDsl.effects.gainPlayAction(ConnectThePeoplePlayDisguisedAction)
+                            ]
+                        }),
+                        AbilityDsl.actions.playCard({ ignoredRequirements: ['location'] })
+                    ])
+                })
+            ]),
+            max:AbilityDsl.limit.perRound(1)
+        });
+    }
+}
+
+ToConnectThePeople.id = 'to-connect-the-people';
+
+module.exports = ToConnectThePeople;

--- a/server/game/cards/19.1-AS01/Neutral/ToGovernTheLand.js
+++ b/server/game/cards/19.1-AS01/Neutral/ToGovernTheLand.js
@@ -1,0 +1,84 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { ConflictTypes, CardTypes, TargetModes } = require('../../../Constants.js');
+
+class ToGovernTheLand extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Send home and bow based on bushi\'s power',
+            condition: (context) => this.governCondition(ConflictTypes.Political, context),
+            target: {
+                cardType: CardTypes.Character,
+                mode: TargetModes.Single,
+                cardCondition: (card, context) => this.governCardCondition(ConflictTypes.Political, card, context),
+                gameAction: this.governGameAction()
+            }
+        });
+
+        this.action({
+            title: 'Send home and bow based on courtier\'s power',
+            condition: (context) => this.governCondition(ConflictTypes.Military, context),
+            target: {
+                cardType: CardTypes.Character,
+                mode: TargetModes.Single,
+                cardCondition: (card, context) => this.governCardCondition(ConflictTypes.Military, card, context),
+                gameAction: this.governGameAction()
+            }
+        });
+    }
+
+    governSkill(conflictType, card) {
+        switch(conflictType) {
+            case ConflictTypes.Political:
+                return card.getMilitarySkill();
+            case ConflictTypes.Military:
+                return card.getPoliticalSkill();
+            default:
+                return NaN;
+        }
+    }
+
+    governFulfillTrait(conflictType, context, card) {
+        switch(conflictType) {
+            case ConflictTypes.Political:
+                return card.controller === context.player && card.hasTrait('bushi');
+            case ConflictTypes.Military:
+                return card.controller === context.player && card.hasTrait('courtier');
+            default:
+                return false;
+        }
+    }
+
+    governCondition(conflictType, context) {
+        return (
+            context.game.isDuringConflict(conflictType) &&
+            context.game.currentConflict
+                .getParticipants()
+                .some((card) => this.governFulfillTrait(conflictType, context, card))
+        );
+    }
+
+    governCardCondition(conflictType, card, context) {
+        if(!card.isParticipating()) {
+            return false;
+        }
+
+        let maxSkillExclusive = context.game.currentConflict.getParticipants().reduce((max, myCard) => {
+            if(!this.governFulfillTrait(conflictType, context, myCard)) {
+                return max;
+            }
+
+            let milSkill = this.governSkill(conflictType, myCard);
+            return milSkill > max ? milSkill : max;
+        }, 0);
+        return this.governSkill(conflictType, card) < maxSkillExclusive;
+    }
+
+    governGameAction() {
+        return AbilityDsl.actions.multiple([AbilityDsl.actions.sendHome(), AbilityDsl.actions.bow()]);
+    }
+}
+
+ToGovernTheLand.id = 'to-govern-the-land';
+
+module.exports = ToGovernTheLand;

--- a/server/game/cards/19.1-AS01/Neutral/ToShowThePath.js
+++ b/server/game/cards/19.1-AS01/Neutral/ToShowThePath.js
@@ -1,0 +1,36 @@
+const AbilityDsl = require('../../../abilitydsl');
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, Durations, Players, TargetModes } = require('../../../Constants.js');
+
+class ToShowThePath extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Target unit costs more fate to target',
+            condition: (context) =>
+                context.player.cardsInPlay.some((card) => card.hasTrait('monk') || card.hasTrait('shugenja')),
+            target: {
+                cardType: CardTypes.Character,
+                controller: Players.Self,
+                mode: TargetModes.Single,
+                cardCondition: (card) => !card.hasTrait('monk') && !card.hasTrait('shugenja'),
+                gameAction: AbilityDsl.actions.playerLastingEffect((context) => ({
+                    targetController: context.player.opponent,
+                    duration: Durations.UntilEndOfPhase,
+                    effect: AbilityDsl.effects.playerFateCostToTargetCard({
+                        amount: 1,
+                        targetPlayer: context.target.controller === context.player ? Players.Opponent : Players.Self,
+                        match: (card) =>
+                            card === context.target ||
+                            context.target.attachments.some((attachment) => attachment === card)
+                    })
+                }))
+            },
+            effect: 'make {1} pay 1 additional fate as a cost whenever they target {0} or its attachments with a card ability until the end of the phase',
+            effectArgs: (context) => [context.source.controller.opponent]
+        });
+    }
+}
+
+ToShowThePath.id = 'to-show-the-path';
+
+module.exports = ToShowThePath;

--- a/server/game/cards/19.1-AS01/Neutral/ToSowTheEarth.js
+++ b/server/game/cards/19.1-AS01/Neutral/ToSowTheEarth.js
@@ -1,0 +1,85 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Players, TargetModes, Locations, PlayTypes } = require('../../../Constants.js');
+const PlayCharacterAction = require('../../../playcharacteraction.js');
+const PlayDisguisedCharacterAction = require('../../../PlayDisguisedCharacterAction.js');
+
+class ToSowTheEarthPlayAction extends PlayCharacterAction {
+    constructor(card) {
+        super(card, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location') ? ignoredRequirements : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+class ToSowTheEarthPlayDisguisedAction extends PlayDisguisedCharacterAction {
+    constructor(card) {
+        super(card, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location') ? ignoredRequirements : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+
+class ToSowTheEarth extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Play a peasant from the discard pile',
+            target: {
+                cardType: CardTypes.Character,
+                controller: Players.Self,
+                location: [Locations.ConflictDiscardPile, Locations.DynastyDiscardPile],
+                mode: TargetModes.Single,
+                cardCondition: card => card.hasTrait('peasant'),
+                gameAction: AbilityDsl.actions.sequential([
+                    AbilityDsl.actions.cardLastingEffect(context => ({
+                        target: context.target,
+                        effect: [
+                            AbilityDsl.effects.gainPlayAction(ToSowTheEarthPlayAction),
+                            AbilityDsl.effects.gainPlayAction(ToSowTheEarthPlayDisguisedAction)
+                        ]
+                    })),
+                    AbilityDsl.actions.playCard(context => ({
+                        target: context.target
+                    }))
+                ])
+            },
+            effect: 'play {0} from their discard pile'
+        });
+
+        this.action({
+            title: 'Place a province facedown',
+            cost: AbilityDsl.costs.bow({
+                cardCondition: card => card.hasTrait('peasant')
+            }),
+            target: {
+                cardType: CardTypes.Province,
+                location: Locations.Provinces,
+                controller: Players.Any,
+                cardCondition: card => card.isBroken === false,
+                gameAction: AbilityDsl.actions.turnFacedown()
+            },
+            max: AbilityDsl.limit.perRound(1)
+        });
+    }
+}
+
+ToSowTheEarth.id = 'to-sow-the-earth';
+
+module.exports = ToSowTheEarth;

--- a/server/game/cards/19.1-AS01/Neutral/WritOfSanctification.js
+++ b/server/game/cards/19.1-AS01/Neutral/WritOfSanctification.js
@@ -1,0 +1,36 @@
+const DrawCard = require('../../../drawcard.js');
+const { AbilityTypes, CardTypes, Players, TargetModes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class WritOfSanctification extends DrawCard {
+    setupCardAbilities() {
+        this.attachmentConditions({
+            limitTrait: { 'title': 1 },
+            trait: 'shugenja'
+        });
+
+        this.persistentEffect({
+            condition: context => !context.player.cardsInPlay.some(card => (card.hasTrait('shadowlands') || card.hasTrait('haunted'))
+                && card.type === CardTypes.Character),
+            effect: AbilityDsl.effects.addKeyword('ancestral')
+        });
+
+        this.whileAttached({
+            effect: AbilityDsl.effects.gainAbility(AbilityTypes.Action, {
+                title: 'Bow shadowlands or haunted',
+                condition: context => context.source.isParticipating(),
+                target: {
+                    cardType: CardTypes.Character,
+                    controller: Players.Any,
+                    mode: TargetModes.Single,
+                    cardCondition: card => card.isParticipating() && (card.hasTrait('haunted') || card.hasTrait('shadowlands') || card.isTainted),
+                    gameAction: AbilityDsl.actions.bow()
+                }
+            })
+        });
+    }
+}
+
+WritOfSanctification.id = 'writ-of-sanctification';
+
+module.exports = WritOfSanctification;

--- a/server/game/cards/19.1-AS01/Neutral/WritOfSurvey.js
+++ b/server/game/cards/19.1-AS01/Neutral/WritOfSurvey.js
@@ -1,0 +1,38 @@
+const DrawCard = require('../../../drawcard.js');
+const { AbilityTypes, CardTypes, Players, TargetModes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class WritOfSurvey extends DrawCard {
+    setupCardAbilities() {
+        this.attachmentConditions({
+            limitTrait: { 'title': 1 }
+        });
+
+        this.persistentEffect({
+            condition: context => context.source.parent.isHonored,
+            effect: AbilityDsl.effects.addKeyword('ancestral')
+        });
+
+        this.whileAttached({
+            effect: AbilityDsl.effects.gainAbility(AbilityTypes.Action, {
+                title: 'Bow a participating dishonored character',
+                condition: context => context.source.isParticipating(),
+                target: {
+                    cardType: CardTypes.Character,
+                    controller: Players.Any,
+                    mode: TargetModes.Single,
+                    cardCondition: card => card.isParticipating() && card.isDishonored,
+                    gameAction: AbilityDsl.actions.bow()
+                }
+            })
+        });
+    }
+
+    canPlayOn(source) {
+        return source.isHonored && super.canPlayOn(source);
+    }
+}
+
+WritOfSurvey.id = 'writ-of-survey';
+
+module.exports = WritOfSurvey;

--- a/server/game/cards/19.1-AS01/Neutral/YatakabunePort.js
+++ b/server/game/cards/19.1-AS01/Neutral/YatakabunePort.js
@@ -1,0 +1,20 @@
+const AbilityDsl = require('../../../abilitydsl');
+const ProvinceCard = require('../../../provincecard.js');
+
+class YatakabunePort extends ProvinceCard {
+    setupCardAbilities() {
+        this.interrupt({
+            title: 'Claim the imperial favor',
+            when: {
+                onBreakProvince: (event, context) => event.card === context.source && context.game.currentConflict && context.game.currentConflict.attackingPlayer && context.game.currentConflict.attackingPlayer.hand.size() > 0
+            },
+            gameAction: AbilityDsl.actions.claimImperialFavor(context => ({
+                target: context.player
+            }))
+        });
+    }
+}
+
+YatakabunePort.id = 'yatakabune-port';
+
+module.exports = YatakabunePort;

--- a/server/game/cards/19.1-AS01/Phoenix/CeremonialRobes.js
+++ b/server/game/cards/19.1-AS01/Phoenix/CeremonialRobes.js
@@ -1,0 +1,100 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, Locations, Players } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+class CeremonialRobes extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            effect: AbilityDsl.effects.modifyGlory((character, context) =>
+                context.player.cardsInPlay.reduce(
+                    (sum, card) => (card.type === CardTypes.Character && card.hasTrait('spirit') ? sum + 1 : sum),
+                    0
+                )
+            )
+        });
+
+        this.action({
+            title: 'Place a card from your deck faceup on a province',
+            effect: 'look at the top 3 cards of their dynasty deck',
+            target: {
+                location: Locations.Provinces,
+                cardType: CardTypes.Province,
+                cardCondition: (card) => card.location !== Locations.StrongholdProvince,
+                controller: Players.Self
+            },
+            handler: (context) => {
+                let top3Cards = context.player.dynastyDeck.first(3);
+                let steps = [
+                    {
+                        activePromptTitle: 'Select a card to put into the province faceup',
+                        message: '{0} places {1} into their province',
+                        callback: (chosenCard) => {
+                            context.player.moveCard(chosenCard, context.target.location);
+                            chosenCard.facedown = false;
+                        }
+                    },
+                    {
+                        activePromptTitle: 'Select a card to put on the bottom of the deck',
+                        message: '{0} places a card on the bottom of the deck',
+                        callback: (chosenCard) => context.player.moveCard(chosenCard, 'dynasty deck bottom')
+                    },
+                    {
+                        activePromptTitle: 'Select a card to discard',
+                        message: '{0} discards {1}',
+                        callback: (chosenCard) => {
+                            context.player.moveCard(chosenCard, Locations.DynastyDiscardPile);
+                            if(chosenCard.hasTrait('spirit')) {
+                                this.game.addMessage(
+                                    '{0} was a Spirit! {1} and {2} lose 1 honor',
+                                    chosenCard,
+                                    context.player,
+                                    context.player.opponent
+                                );
+                                AbilityDsl.actions
+                                    .loseHonor((context) => ({
+                                        target: context.game.getPlayers()
+                                    }))
+                                    .resolve(chosenCard, context);
+                            }
+                        }
+                    }
+                ];
+
+                this.ceremonialRobesPrompt(steps, context, top3Cards);
+            }
+        });
+    }
+
+    ceremonialRobesPrompt(remainingSteps, context, selectableCards) {
+        let currentStep = remainingSteps.shift();
+        if(!currentStep) {
+            return;
+        }
+        if(selectableCards.length === 0) {
+            return;
+        }
+        if(selectableCards.length === 1) {
+            let lastCard = selectableCards[0];
+            this.game.addMessage(currentStep.message, context.player, lastCard, context.target);
+            currentStep.callback(lastCard);
+            return;
+        }
+
+        this.game.promptWithHandlerMenu(context.player, {
+            activePromptTitle: currentStep.activePromptTitle,
+            context: context,
+            cards: selectableCards,
+            cardHandler: (selectedCard) => {
+                this.game.addMessage(currentStep.message, context.player, selectedCard, context.target);
+                currentStep.callback(selectedCard);
+
+                let newSelectableCards = selectableCards.filter((c) => c !== selectedCard);
+                this.ceremonialRobesPrompt(remainingSteps, context, newSelectableCards);
+            }
+        });
+    }
+}
+
+CeremonialRobes.id = 'ceremonial-robes';
+
+module.exports = CeremonialRobes;

--- a/server/game/cards/19.1-AS01/Phoenix/Firebrand.js
+++ b/server/game/cards/19.1-AS01/Phoenix/Firebrand.js
@@ -1,0 +1,41 @@
+const DrawCard = require('../../../drawcard.js');
+const { Elements } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+const elementKeys = {
+    cost: 'firebrand-fire-cost',
+    ability: 'firebrand-fire-ability'
+};
+
+class Firebrand extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Resolve the fire ring',
+            cost: AbilityDsl.costs.returnRings(1, ring => ring.hasElement(this.getCurrentElementSymbol(elementKeys.cost))),
+            gameAction: AbilityDsl.actions.resolveRingEffect(context => ({
+                player: context.player,
+                target: context.game.rings[this.getCurrentElementSymbol(elementKeys.ability)]
+            })),
+            effect: 'resolve the {1} effect',
+            effectArgs: context => [context.game.rings.fire]
+        });
+    }
+
+    getPrintedElementSymbols() {
+        let symbols = super.getPrintedElementSymbols();
+        symbols.push({
+            key: elementKeys.cost,
+            prettyName: 'Ring to return',
+            element: Elements.Fire
+        });
+        symbols.push({
+            key: elementKeys.ability,
+            prettyName: 'Ring to resolve',
+            element: Elements.Fire
+        });
+        return symbols;
+    }
+}
+
+Firebrand.id = 'firebrand';
+
+module.exports = Firebrand;

--- a/server/game/cards/19.1-AS01/Phoenix/GregariousWard.js
+++ b/server/game/cards/19.1-AS01/Phoenix/GregariousWard.js
@@ -1,0 +1,22 @@
+const AbilityDsl = require('../../../abilitydsl.js');
+const DrawCard = require('../../../drawcard.js');
+
+class GregariousWard extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Gain fate',
+            when: {
+                afterConflict: (event, context) =>
+                    event.conflict.winner === context.source.controller &&
+                    context.source.isParticipating() &&
+                    context.game.currentConflict.hasMoreParticipants(context.player)
+            },
+            gameAction: AbilityDsl.actions.placeFate(),
+            max: AbilityDsl.limit.perConflict(1)
+        });
+    }
+}
+
+GregariousWard.id = 'gregarious-ward';
+
+module.exports = GregariousWard;

--- a/server/game/cards/19.1-AS01/Phoenix/ParanoidHososhi.js
+++ b/server/game/cards/19.1-AS01/Phoenix/ParanoidHososhi.js
@@ -1,0 +1,39 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Phases, Players } = require('../../../Constants');
+
+class ParanoidHososhi extends DrawCard {
+    setupCardAbilities() {
+        this.legendary(2);
+
+        this.interrupt({
+            title: 'Steal fate from a character',
+            when: {
+                onPhaseEnded: (event) => event.phase === Phases.Conflict
+            },
+            cost: AbilityDsl.costs.bowSelf(),
+            target: {
+                controller: Players.Any,
+                cardType: CardTypes.Character,
+                cardCondition: (card, context) => card.getCost() === this.getHighestCostOfCharactersInPlay(context),
+                gameAction: AbilityDsl.actions.removeFate((context) => ({
+                    amount: 1,
+                    recipient: context.player
+                }))
+            },
+            effect: 'take 1 fate from {0} — evil begone!'
+        });
+    }
+
+    getHighestCostOfCharactersInPlay(context) {
+        let charactersInPlay = context.game.findAnyCardsInPlay((c) => c.type === CardTypes.Character);
+        return charactersInPlay.reduce((prevHighestCost, c) => {
+            let cost = c.getCost();
+            return typeof cost === 'number' && cost > prevHighestCost ? cost : prevHighestCost;
+        }, 0);
+    }
+}
+
+ParanoidHososhi.id = 'paranoid-hososhi';
+
+module.exports = ParanoidHososhi;

--- a/server/game/cards/19.1-AS01/Phoenix/ServitorOfStone.js
+++ b/server/game/cards/19.1-AS01/Phoenix/ServitorOfStone.js
@@ -1,0 +1,37 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+class ServitorOfStone extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            condition: (context) =>
+                this.controllerHasShugenjaAtSameLocation(context),
+            effect: AbilityDsl.effects.cardCannot({ cannot: 'leavePlay' })
+        });
+
+        this.persistentEffect({
+            effect: AbilityDsl.effects.delayedEffect({
+                condition: (context) =>
+                    !this.controllerHasShugenjaAtSameLocation(context),
+                message:
+                    '{0} is discarded from play because {1} controls no Shugenja at their location',
+                messageArgs: (context) => [context.source, context.player],
+                gameAction: AbilityDsl.actions.discardFromPlay()
+            })
+        });
+    }
+
+    controllerHasShugenjaAtSameLocation(context) {
+        return context.player.anyCardsInPlay(
+            (otherCard) =>
+                otherCard.type === CardTypes.Character &&
+                otherCard.hasTrait('shugenja') &&
+                context.source.isInConflict() === otherCard.isInConflict()
+        );
+    }
+}
+
+ServitorOfStone.id = 'servitor-of-stone';
+
+module.exports = ServitorOfStone;

--- a/server/game/cards/19.1-AS01/Phoenix/ShibasOath.js
+++ b/server/game/cards/19.1-AS01/Phoenix/ShibasOath.js
@@ -1,0 +1,58 @@
+const DrawCard = require('../../../drawcard.js');
+const { CardTypes, AbilityTypes, Locations, Phases } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+class ShibasOath extends DrawCard {
+    setupCardAbilities() {
+        this.attachmentConditions({
+            limitTrait: { title: 1 },
+            cardCondition: (card) => card.hasTrait('bushi')
+        });
+
+        this.persistentEffect({
+            condition: (context) => context.game.currentPhase === Phases.Conflict,
+            effect: AbilityDsl.effects.addKeyword('ancestral')
+        });
+
+        this.reaction({
+            title: 'Honor attached character',
+            when: {
+                onCardAttached: (event, context) =>
+                    event.card === context.source && event.originalLocation !== Locations.PlayArea
+            },
+            gameAction: AbilityDsl.actions.honor((context) => ({
+                target: context.source.parent
+            })),
+            effect: 'honor {1}',
+            effectArgs: (context) => context.source.parent
+        });
+
+        this.whileAttached({
+            effect: AbilityDsl.effects.gainAbility(AbilityTypes.WouldInterrupt, {
+                title: 'Cancel an ability',
+                when: {
+                    onInitiateAbilityEffects: (event, context) =>
+                        event.cardTargets.some(
+                            (card) =>
+                                // In play
+                                card.location === Locations.PlayArea &&
+                                // Character
+                                card.getType() === CardTypes.Character &&
+                                // Friendly
+                                card.controller === context.player &&
+                                // Not a Bushi
+                                !card.hasTrait('bushi')
+                        )
+                },
+                cost: AbilityDsl.costs.sacrificeSelf(),
+                gameAction: AbilityDsl.actions.cancel(),
+                effect: 'cancel the effects of {1}',
+                effectArgs: (context) => [context.event.card]
+            })
+        });
+    }
+}
+
+ShibasOath.id = 'shiba-s-oath';
+
+module.exports = ShibasOath;

--- a/server/game/cards/19.1-AS01/Phoenix/TheEmptyCity.js
+++ b/server/game/cards/19.1-AS01/Phoenix/TheEmptyCity.js
@@ -1,0 +1,80 @@
+const ProvinceCard = require('../../../provincecard.js');
+const AbilityDsl = require('../../../abilitydsl.js');
+const { CardTypes, Durations, EventNames, Locations, Players, TargetModes } = require('../../../Constants');
+const EventRegistrar = require('../../../eventregistrar.js');
+
+class TheEmptyCity extends ProvinceCard {
+    setupCardAbilities() {
+        this.eventRegistrar = new EventRegistrar(this.game, this);
+        this.eventRegistrar.register([EventNames.OnRoundEnded, EventNames.OnCardLeavesPlay]);
+
+        this.action({
+            title: 'Claim a ring',
+            canTriggerOutsideConflict: true,
+            cost: AbilityDsl.costs.bow({
+                cardType: CardTypes.Character,
+                cardCondition: (card) => card.hasTrait('spirit')
+            }),
+            target: {
+                mode: TargetModes.Ring,
+                activePromptTitle: 'Choose an unclaimed ring',
+                ringCondition: (ring) => ring.isUnclaimed(),
+                gameAction: AbilityDsl.actions.joint([
+                    AbilityDsl.actions.claimRing({
+                        takeFate: false,
+                        type: 'political'
+                    }),
+                    AbilityDsl.actions.cardLastingEffect((context) => ({
+                        target: context.source,
+                        effect: AbilityDsl.effects.cardCannot('triggerAbilities'),
+                        duration: Durations.UntilEndOfRound
+                    }))
+                ])
+            },
+            effect: 'claim {0} as a political ring'
+        });
+
+        this.action({
+            title: 'Put a Spirit character into play',
+            canTriggerOutsideConflict: true,
+            target: {
+                cardType: CardTypes.Character,
+                controller: Players.Self,
+                location: [Locations.ConflictDiscardPile, Locations.DynastyDiscardPile],
+                cardCondition: (card) => card.hasTrait('spirit') && card.getCost() <= 2,
+                gameAction: AbilityDsl.actions.joint([
+                    AbilityDsl.actions.putIntoPlay(),
+                    AbilityDsl.actions.cardLastingEffect((context) => ({
+                        target: context.source,
+                        effect: AbilityDsl.effects.cardCannot('triggerAbilities'),
+                        duration: Durations.UntilEndOfRound
+                    }))
+                ])
+            },
+            effect: 'put {0} into play',
+            then: (context) => {
+                this.invokedSpirit = context.target;
+                return { gameAction: AbilityDsl.actions.noAction() };
+            }
+        });
+    }
+
+    onRoundEnded() {
+        this.invokedSpirit = undefined;
+    }
+
+    onCardLeavesPlay(event) {
+        if(this.invokedSpirit && this.invokedSpirit === event.card && this.location !== Locations.RemovedFromGame) {
+            this.game.addMessage(
+                '{1} is removed from the game, as it was invoked by the {0} this round',
+                this,
+                event.card
+            );
+            this.owner.moveCard(event.card, Locations.RemovedFromGame);
+        }
+    }
+}
+
+TheEmptyCity.id = 'the-empty-city';
+
+module.exports = TheEmptyCity;

--- a/server/game/cards/19.1-AS01/Phoenix/VigilantGuardian.js
+++ b/server/game/cards/19.1-AS01/Phoenix/VigilantGuardian.js
@@ -1,0 +1,15 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl.js');
+
+class VigilantGuardian extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            condition: (context) => context.source.isDefending() && context.game.currentConflict.attackerSkill === 0,
+            effect: AbilityDsl.effects.doesNotBow()
+        });
+    }
+}
+
+VigilantGuardian.id = 'vigilant-guardian';
+
+module.exports = VigilantGuardian;

--- a/server/game/cards/19.1-AS01/Scorpion/AncientStoneGuardian.js
+++ b/server/game/cards/19.1-AS01/Scorpion/AncientStoneGuardian.js
@@ -1,0 +1,81 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Players } = require('../../../Constants.js');
+
+class AncientStoneGuardian extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            effect: [AbilityDsl.effects.cardCannot('declareAsAttacker')]
+        });
+
+        this.persistentEffect({
+            effect: AbilityDsl.effects.cardCannot({ cannot: 'applyCovert', restricts: 'opponentsCardEffects' })
+        });
+
+        this.forcedInterrupt({
+            title: 'Dishonor a character and draw a card',
+            when: {
+                onCardLeavesPlay: (event, context) => event.card === context.source
+            },
+            targets: {
+                firstCharacter: {
+                    activePromptTitle: 'Choose a character',
+                    cardType: CardTypes.Character,
+                    optional: true,
+                    hideIfNoLegalTargets: true,
+                    controller: (context) => (context.player.firstPlayer ? Players.Self : Players.Opponent),
+                    player: (context) => (context.player.firstPlayer ? Players.Self : Players.Opponent),
+                    cardCondition: (card, context) => this._stoneGuardianCardCondition(card, context),
+                    gameAction: AbilityDsl.actions.sequentialContext((context) =>
+                        this._stoneGuardianSequence(context.targets.firstCharacter)
+                    )
+                },
+                secondCharacter: {
+                    activePromptTitle: 'Choose a character',
+                    cardType: CardTypes.Character,
+                    optional: true,
+                    hideIfNoLegalTargets: true,
+                    controller: (context) => (context.player.firstPlayer ? Players.Opponent : Players.Self),
+                    player: (context) => (context.player.firstPlayer ? Players.Opponent : Players.Self),
+                    cardCondition: (card, context) => this._stoneGuardianCardCondition(card, context),
+                    gameAction: AbilityDsl.actions.sequentialContext((context) =>
+                        this._stoneGuardianSequence(context.targets.secondCharacter)
+                    )
+                }
+            },
+
+            effect: 'present an opportunity to sneak around {0} and find some secrets!{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}',
+            effectArgs: (context) =>
+                this._stoneGuardianEffectParts(context.targets.firstCharacter).concat(
+                    this._stoneGuardianEffectParts(context.targets.secondCharacter)
+                )
+        });
+    }
+
+    _stoneGuardianCardCondition(card, context) {
+        return card !== context.source && AbilityDsl.actions.dishonor({ target: card }).canAffect(card, context);
+    }
+
+    _stoneGuardianSequence(target) {
+        return {
+            gameActions: [
+                AbilityDsl.actions.dishonor({ target: target }),
+                AbilityDsl.actions.draw({ target: target.controller })
+            ]
+        };
+    }
+
+    _stoneGuardianEffectParts(target) {
+        if(target instanceof DrawCard) {
+            // Target selected
+            return [' ', target.controller, ' dishonors ', target, ' to draw a card.'];
+        }
+        // Target skipped
+        return ['', '', '', '', ''];
+
+    }
+}
+
+AncientStoneGuardian.id = 'ancient-stone-guardian';
+
+module.exports = AncientStoneGuardian;

--- a/server/game/cards/19.1-AS01/Scorpion/DisloyalOathkeeper.js
+++ b/server/game/cards/19.1-AS01/Scorpion/DisloyalOathkeeper.js
@@ -1,0 +1,39 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { Locations, Players, PlayTypes, CardTypes } = require('../../../Constants.js');
+
+class DisloyalOathkeeper extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            location: Locations.PlayArea,
+            targetLocation: this.uuid,
+            targetController: Players.Self,
+            match: card => {
+                return card.location === this.uuid;
+            },
+            effect: [
+                AbilityDsl.effects.canPlayFromOutOfPlay(player => {
+                    return player === this.controller;
+                }, PlayTypes.PlayFromHand),
+                AbilityDsl.effects.registerToPlayFromOutOfPlay()
+            ]
+        });
+
+        this.reaction({
+            title: 'Put card under this',
+            when: {
+                onCardPlayed: (event, context) => event.player === context.player.opponent && event.card.type === CardTypes.Event &&
+                context.source.controller.getSourceList(this.uuid).map(a => a).length === 0
+            },
+            gameAction: AbilityDsl.actions.placeCardUnderneath(context => ({
+                target: context.event.card,
+                hideWhenFaceup: true,
+                destination: this
+            }))
+        });
+    }
+}
+
+DisloyalOathkeeper.id = 'disloyal-oathkeeper';
+
+module.exports = DisloyalOathkeeper;

--- a/server/game/cards/19.1-AS01/Scorpion/IllusionaryDecoy.js
+++ b/server/game/cards/19.1-AS01/Scorpion/IllusionaryDecoy.js
@@ -1,0 +1,64 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Locations, Players } = require('../../../Constants.js');
+
+class IllusionaryDecoy extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Put into play',
+            location: Locations.Hand,
+            when: {
+                onConflictStarted: (event, context) =>
+                    context.player.anyCardsInPlay((card) => card.hasTrait('shugenja'))
+            },
+            gameAction: AbilityDsl.actions.multiple([
+                AbilityDsl.actions.putIntoConflict((context) => ({
+                    target: context.source
+                })),
+                AbilityDsl.actions.chooseAction((context) => {
+                    let moveChoice = 'Move another of your characters home';
+                    let stayChoice = 'Done';
+                    return {
+                        messages: {
+                            [moveChoice]: '', // Don't want messages here
+                            [stayChoice]: '' // Don't want messages here
+                        },
+                        choices: {
+                            [moveChoice]: AbilityDsl.actions.selectCard({
+                                controller: Players.Self,
+                                cardType: CardTypes.Character,
+                                cardCondition: (card) => card.isParticipating(),
+                                message: '{0} moves home {1} - they were an {2}!',
+                                messageArgs: (card, player) => [player, card, context.source],
+                                gameAction: AbilityDsl.actions.sendHome()
+                            }),
+                            [stayChoice]: AbilityDsl.actions.noAction()
+                        }
+                    };
+                })
+            ]),
+            effect: 'put {0} into play in the conflict',
+            max: AbilityDsl.limit.perConflict(1)
+        });
+
+        this.action({
+            title: 'Return to hand',
+            condition: (context) => {
+                const claimedRings = context.source.controller.getClaimedRings();
+                const matchShugenjaElementWithClaimedRing = context.source.controller.cardsInPlay.any((card) => {
+                    return (
+                        card.getType() === CardTypes.Character &&
+                        card.hasTrait('shugenja') &&
+                        claimedRings.some((ring) => ring.getElements().some((element) => card.hasTrait(element)))
+                    );
+                });
+                return matchShugenjaElementWithClaimedRing;
+            },
+            gameAction: AbilityDsl.actions.returnToHand()
+        });
+    }
+}
+
+IllusionaryDecoy.id = 'illusionary-decoy';
+
+module.exports = IllusionaryDecoy;

--- a/server/game/cards/19.1-AS01/Scorpion/JadeColoredRocks.js
+++ b/server/game/cards/19.1-AS01/Scorpion/JadeColoredRocks.js
@@ -1,0 +1,34 @@
+const AbilityDsl = require('../../../abilitydsl');
+const { Players, TargetModes } = require('../../../Constants');
+const ProvinceCard = require('../../../provincecard.js');
+
+class JadeColoredRocks extends ProvinceCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Make your opponent lose a resource',
+            target: {
+                mode: TargetModes.Select,
+                player: Players.Self,
+                activePromptTitle: 'Choose an option',
+                choices: {
+                    'Opponent loses 1 fate': AbilityDsl.actions.loseFate(context => ({
+                        amount: 1,
+                        target: context.player.opponent
+                    })),
+                    'Opponent loses 1 honor': AbilityDsl.actions.loseHonor(context => ({
+                        amount: 1,
+                        target: context.player.opponent.honor > 6 ? context.player.opponent : []
+                    })),
+                    'Opponent discards 1 card at random': AbilityDsl.actions.discardAtRandom(context => ({
+                        amount: 1,
+                        target: context.player.opponent
+                    }))
+                }
+            }
+        });
+    }
+}
+
+JadeColoredRocks.id = 'jade-colored-rocks';
+
+module.exports = JadeColoredRocks;

--- a/server/game/cards/19.1-AS01/Scorpion/KagiNawa.js
+++ b/server/game/cards/19.1-AS01/Scorpion/KagiNawa.js
@@ -1,0 +1,27 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { AbilityTypes, CardTypes, Players } = require('../../../Constants.js');
+
+class KagiNawa extends DrawCard {
+    setupCardAbilities() {
+        this.whileAttached({
+            match: (card) => card.hasTrait('shinobi'),
+            effect: AbilityDsl.effects.gainAbility(AbilityTypes.Action, {
+                title: 'Move a character to the conflict',
+                condition: (context) => context.source.isParticipating(),
+                target: {
+                    cardType: CardTypes.Character,
+                    controller: Players.Any,
+                    activePromptTitle: 'Choose a character with printed cost 2 or lower to move in',
+                    cardCondition: (card) => !card.isParticipating() && card.printedCost <= 2,
+                    gameAction: AbilityDsl.actions.moveToConflict()
+                },
+                effect: 'hook {0} and drag them into the conflict'
+            })
+        });
+    }
+}
+
+KagiNawa.id = 'kagi-nawa';
+
+module.exports = KagiNawa;

--- a/server/game/cards/19.1-AS01/Scorpion/SneakAttack.js
+++ b/server/game/cards/19.1-AS01/Scorpion/SneakAttack.js
@@ -1,0 +1,37 @@
+const AbilityDsl = require('../../../abilitydsl');
+const DrawCard = require('../../../drawcard.js');
+
+class SneakAttack extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'The attacker gets the first action opportunity',
+            cost: AbilityDsl.costs.payHonor(1),
+            when: {
+                onConflictStarted: (event, context) => event.conflict.attackingPlayer === context.player
+            },
+            effect: 'give {1} the first action in this conflict{2}',
+            effectArgs: (context) => [
+                context.player,
+                context.player.opponent.hand.size() > 0 ? ' and peak at their opponent\'s hand' : ''
+            ],
+            gameAction: AbilityDsl.actions.sequential([
+                AbilityDsl.actions.lookAt((context) => ({
+                    target: context.player.opponent.hand
+                        .shuffle()
+                        .slice(0, 2)
+                        .sort((a, b) => a.name.localeCompare(b.name)),
+                    message: '{0} sees {1} in {2}\'s hand',
+                    messageArgs: (cards) => [context.player, cards, context.player.opponent]
+                })),
+                AbilityDsl.actions.playerLastingEffect((context) => ({
+                    targetController: context.player,
+                    effect: AbilityDsl.effects.gainActionPhasePriority()
+                }))
+            ])
+        });
+    }
+}
+
+SneakAttack.id = 'sneak-attack';
+
+module.exports = SneakAttack;

--- a/server/game/cards/19.1-AS01/Scorpion/UndergroundOphidiarium.js
+++ b/server/game/cards/19.1-AS01/Scorpion/UndergroundOphidiarium.js
@@ -1,0 +1,25 @@
+const AbilityDsl = require('../../../abilitydsl.js');
+const { CardTypes, Locations } = require('../../../Constants.js');
+const DrawCard = require('../../../drawcard.js');
+
+class UndergroundOphidiarium extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Search for a Poison',
+            effect: 'search conflict deck to reveal a poison attachment and add it to their hand',
+            cost: AbilityDsl.costs.sacrificeSelf(),
+            gameAction: AbilityDsl.actions.deckSearch({
+                cardCondition: (card) =>
+                    card.type === CardTypes.Attachment &&
+                    card.hasTrait('poison'),
+                gameAction: AbilityDsl.actions.moveCard({
+                    destination: Locations.Hand
+                })
+            })
+        });
+    }
+}
+
+UndergroundOphidiarium.id = 'underground-ophidiarium';
+
+module.exports = UndergroundOphidiarium;

--- a/server/game/cards/19.1-AS01/Scorpion/ZealousInspector.js
+++ b/server/game/cards/19.1-AS01/Scorpion/ZealousInspector.js
@@ -1,0 +1,37 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Durations } = require('../../../Constants');
+
+class ZealousInspector extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Take an additional action',
+            when: {
+                onCardDishonored: (event, context) => {
+                    const isCharacter = event.card.type === CardTypes.Character;
+                    const controlledByAnOpponent =
+                        event.card.controller === context.player.opponent;
+                    const dishonoredByYourCardEffect =
+                        context.player === event.context.player &&
+                        event.context.source.type !== 'ring';
+
+                    return (
+                        isCharacter &&
+                        controlledByAnOpponent &&
+                        dishonoredByYourCardEffect
+                    );
+                }
+            },
+            gameAction: AbilityDsl.actions.playerLastingEffect((context) => ({
+                targetController: context.player,
+                duration: Durations.UntilPassPriority,
+                effect: AbilityDsl.effects.additionalAction(1)
+            })),
+            effect:'gain an additional action — time to deliver swift punishment for the wicked'
+        });
+    }
+}
+
+ZealousInspector.id = 'zealous-inspector';
+
+module.exports = ZealousInspector;

--- a/server/game/cards/19.1-AS01/Unicorn/AshalanLantern.js
+++ b/server/game/cards/19.1-AS01/Unicorn/AshalanLantern.js
@@ -1,0 +1,107 @@
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Decks, Durations, Locations, PlayTypes } = require('../../../Constants.js');
+const DrawCard = require('../../../drawcard.js');
+const PlayCharacterAction = require('../../../playcharacteraction.js');
+const PlayDisguisedCharacterAction = require('../../../PlayDisguisedCharacterAction.js');
+
+class AshalanLanternPlayAction extends PlayCharacterAction {
+    constructor(card) {
+        super(card, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location')
+            ? ignoredRequirements
+            : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+
+class AshalanLanternPlayDisguisedAction extends PlayDisguisedCharacterAction {
+    constructor(card) {
+        super(card, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location')
+            ? ignoredRequirements
+            : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+
+class AshalanLantern extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Play a character from your opponent\'s dynasty deck',
+            condition: (context) => context.game.isDuringConflict(),
+            cost: AbilityDsl.costs.nameCard(),
+            gameAction: AbilityDsl.actions.sequential([
+                AbilityDsl.actions.playerLastingEffect((context) => ({
+                    duration: Durations.UntilPassPriority,
+                    targetController: context.player,
+                    effect: AbilityDsl.effects.reduceNextPlayedCardCost(
+                        3,
+                        (card) => card.name === context.costs.nameCardCost
+                    )
+                })),
+                AbilityDsl.actions.deckSearch((context) => ({
+                    amount: 3,
+                    deck: Decks.DynastyDeck,
+                    player: context.player.opponent,
+                    choosingPlayer: context.player,
+                    shuffle: false,
+                    cardCondition: (card) => card.type === CardTypes.Character && !card.isUnique(),
+                    gameAction: AbilityDsl.actions.sequential([
+                        AbilityDsl.actions.cardLastingEffect({
+                            effect: [
+                                AbilityDsl.effects.gainPlayAction(AshalanLanternPlayAction),
+                                AbilityDsl.effects.gainPlayAction(AshalanLanternPlayDisguisedAction)
+                            ]
+                        }),
+                        AbilityDsl.actions.playCard({
+                            ignoredRequirements: ['location'],
+                            postHandler: () => {
+                                if(!context.source.parent.hasTrait('gaijin')) {
+                                    context.game.addMessage(
+                                        '{0} is not Foreign, their {1} is discarded',
+                                        context.source.parent,
+                                        context.source
+                                    );
+                                    context.player.moveCard(context.source, Locations.ConflictDiscardPile);
+                                }
+                            }
+                        })
+                    ]),
+                    remainingCardsHandler: (context, event, cards) => {
+                        context.game.addMessage(
+                            '{0} puts {1} on the top of {2}\' dynasty deck',
+                            event.player,
+                            cards,
+                            event.player.opponent
+                        );
+                    },
+                    message: '{0} compels {1} into service',
+                    messageArgs: (context, selectedCard) => [context.player, selectedCard]
+                }))
+            ]),
+            effect: 'look for a character on the top of {1}\'s dynasty deck. They reveal {2}',
+            effectArgs: (context) => [context.player.opponent, context.player.opponent.dynastyDeck.first(3)]
+        });
+    }
+}
+AshalanLantern.id = 'ashalan-lantern';
+
+module.exports = AshalanLantern;

--- a/server/game/cards/19.1-AS01/Unicorn/FieldsOfRollingThunder.js
+++ b/server/game/cards/19.1-AS01/Unicorn/FieldsOfRollingThunder.js
@@ -1,0 +1,48 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Durations } = require('../../../Constants');
+
+class FieldsOfRollingThunder extends DrawCard {
+    setupCardAbilities() {
+        this.forcedReaction({
+            title: 'Discard this holding',
+            when: {
+                afterConflict: (event, context) =>
+                    event.conflict.loser === context.player && event.conflict.conflictUnopposed
+            },
+            gameAction: AbilityDsl.actions.discardFromPlay()
+        });
+
+        this.action({
+            title: 'Honor a character',
+            condition: () => this.game.isDuringConflict(),
+            effect: 'honor {0}. They will be dishonored at the end of the conflict if {1} loses the conflict.',
+            effectArgs: (context) => [context.source.controller],
+            target: {
+                cardType: CardTypes.Character,
+                cardCondition: (card) => card.isParticipating() && card.isFaction('unicorn'),
+                gameAction: AbilityDsl.actions.multiple([
+                    AbilityDsl.actions.honor(),
+                    AbilityDsl.actions.cardLastingEffect((context) => {
+                        let conflictWhenItWasTriggered = this.game.currentConflict;
+                        return {
+                            duration: Durations.UntilEndOfPhase,
+                            effect: AbilityDsl.effects.delayedEffect({
+                                when: {
+                                    onConflictFinished: (event, context) =>
+                                        event.conflict === conflictWhenItWasTriggered &&
+                                        event.conflict.winner === context.player.opponent
+                                },
+                                gameAction: AbilityDsl.actions.dishonor({ target: context.target })
+                            })
+                        };
+                    })
+                ])
+            }
+        });
+    }
+}
+
+FieldsOfRollingThunder.id = 'fields-of-rolling-thunder';
+
+module.exports = FieldsOfRollingThunder;

--- a/server/game/cards/19.1-AS01/Unicorn/IchigoKun.js
+++ b/server/game/cards/19.1-AS01/Unicorn/IchigoKun.js
@@ -1,0 +1,71 @@
+const AbilityDsl = require('../../../abilitydsl.js');
+const { Elements, CardTypes, Players, TargetModes } = require('../../../Constants.js');
+const DrawCard = require('../../../drawcard.js');
+
+const elementKey = 'ichigo-kun-fire';
+
+const choice = {
+    moreMillLessGlory: 'Increase own military, reduce other glory',
+    lessMilMoreGlory: 'Reduce own military, increase other glory'
+};
+
+class IchigoKun extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            condition: (context) =>
+                context.game.currentConflict &&
+                context.game.currentConflict.hasElement(this.getCurrentElementSymbol(elementKey)),
+            effect: AbilityDsl.effects.setBaseMilitarySkill(0)
+        });
+
+        this.action({
+            title: 'Modify military skill and glory',
+            targets: {
+                otherCharacter: {
+                    cardType: CardTypes.Character,
+                    controller: Players.Self,
+                    cardCondition: (card, context) => card.isParticipating() && card !== context.source
+                },
+                select: {
+                    mode: TargetModes.Select,
+                    dependsOn: 'otherCharacter',
+                    choices: (context) => ({
+                        [choice.moreMillLessGlory]: this._ichigoActions(context, { military: +2, glory: -2 }),
+                        [choice.lessMilMoreGlory]: this._ichigoActions(context, { military: -2, glory: +2 })
+                    })
+                }
+            },
+            effect: 'give {0} {1} {2} and {3} {4} glory - {0} {5}',
+            effectArgs: (context) =>
+                context.selects.select.choice === choice.moreMillLessGlory
+                    ? ['+2', 'military', context.targets.otherCharacter, '-2', 'is wild today!']
+                    : ['-2', 'military', context.targets.otherCharacter, '+2', 'is well-behaved. Impressive!']
+        });
+    }
+
+    getPrintedElementSymbols() {
+        let symbols = super.getPrintedElementSymbols();
+        symbols.push({ key: elementKey, prettyName: 'Restricted Ring', element: Elements.Fire });
+        return symbols;
+    }
+
+    _ichigoActions(context, modifiers) {
+        return AbilityDsl.actions.sequential([
+            AbilityDsl.actions.moveToConflict({ target: context.source }),
+            AbilityDsl.actions.multiple([
+                AbilityDsl.actions.cardLastingEffect({
+                    target: context.source,
+                    effect: AbilityDsl.effects.modifyMilitarySkill(modifiers.military)
+                }),
+                AbilityDsl.actions.cardLastingEffect({
+                    target: context.targets.otherCharacter,
+                    effect: AbilityDsl.effects.modifyGlory(modifiers.glory)
+                })
+            ])
+        ]);
+    }
+}
+
+IchigoKun.id = 'ichigo-kun';
+
+module.exports = IchigoKun;

--- a/server/game/cards/19.1-AS01/Unicorn/LongJourneyHome.js
+++ b/server/game/cards/19.1-AS01/Unicorn/LongJourneyHome.js
@@ -1,0 +1,33 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { Durations, CardTypes } = require('../../../Constants.js');
+
+class LongJourneyHome extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Bow a character for the phase',
+            when: {
+                onSendHome: (event, context) => this._longJourneyCondition(event, context),
+                onReturnHome: (event, context) => this._longJourneyCondition(event, context)
+            },
+            gameAction: AbilityDsl.actions.multiple([
+                AbilityDsl.actions.bow((context) => ({ target: context.event.card })),
+                AbilityDsl.actions.cardLastingEffect((context) => ({
+                    duration: Durations.UntilEndOfPhase,
+                    target: context.event.card,
+                    effect: AbilityDsl.effects.cardCannot({ cannot: 'ready' })
+                }))
+            ]),
+            effect: 'make {1} take the long way home. {1} is bowed and cannot ready until the end of the phase',
+            effectArgs: (context) => [context.event.card]
+        });
+    }
+
+    _longJourneyCondition(event, context) {
+        return event.card.type === CardTypes.Character && event.card.controller === context.source.controller.opponent;
+    }
+}
+
+LongJourneyHome.id = 'long-journey-home';
+
+module.exports = LongJourneyHome;

--- a/server/game/cards/19.1-AS01/Unicorn/ObsidianCaves.js
+++ b/server/game/cards/19.1-AS01/Unicorn/ObsidianCaves.js
@@ -1,0 +1,23 @@
+const AbilityDsl = require('../../../abilitydsl');
+const { Players, CardTypes } = require('../../../Constants');
+const ProvinceCard = require('../../../provincecard.js');
+
+class ObsidianCaves extends ProvinceCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Attacker moves a character home',
+            target: {
+                cardType: CardTypes.Character,
+                controller: context => context.player.isAttackingPlayer() ? Players.Self : Players.Opponent,
+                player: context => context.player.isAttackingPlayer() ? Players.Self : Players.Opponent,
+                activePromptTitle: 'Choose a character to send home',
+                cardCondition: card => card.isAttacking(),
+                gameAction: AbilityDsl.actions.sendHome()
+            }
+        });
+    }
+}
+
+ObsidianCaves.id = 'obsidian-caves';
+
+module.exports = ObsidianCaves;

--- a/server/game/cards/19.1-AS01/Unicorn/Retribution.js
+++ b/server/game/cards/19.1-AS01/Unicorn/Retribution.js
@@ -1,0 +1,90 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { ConflictTypes, CardTypes, Players, Durations, Locations } = require('../../../Constants.js');
+const GameModes = require('../../../../GameModes.js');
+
+class Retribution extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            title: 'Immediately declare a military conflict',
+            when: {
+                onConflictFinished: (event, context) => this._retributionCondition(event, context)
+            },
+            effect: 'declare a military conflict, attacking with {1}',
+            effectArgs: (context) => [context.target],
+            target: {
+                cardType: CardTypes.Character,
+                controller: Players.Self,
+                cardCondition: (card, context) => this._retributionAttackerFilter(card, context),
+                gameAction: AbilityDsl.actions.sequentialContext((context) => ({
+                    gameActions: [
+                        AbilityDsl.actions.cardLastingEffect({
+                            duration: Durations.UntilEndOfConflict,
+                            effect: AbilityDsl.effects.mustBeDeclaredAsAttacker(),
+                            target: context.target
+                        }),
+                        AbilityDsl.actions.cardLastingEffect({
+                            duration: Durations.UntilEndOfConflict,
+                            effect: AbilityDsl.effects.cardCannot('declareAsAttacker'),
+                            target: context.player.cardsInPlay.filter(
+                                (card) => card.getType() === CardTypes.Character && card !== context.target
+                            )
+                        }),
+                        AbilityDsl.actions.playerLastingEffect({
+                            targetController: context.player,
+                            duration: Durations.UntilEndOfPhase,
+                            effect: AbilityDsl.effects.additionalConflict('military')
+                        }),
+                        AbilityDsl.actions.initiateConflict({
+                            target: context.player,
+                            canPass: false,
+                            forcedDeclaredType: ConflictTypes.Military
+                        })
+                    ]
+                }))
+            },
+            max: AbilityDsl.limit.perRound(1)
+        });
+    }
+
+    _retributionCondition(event, context) {
+        return (
+            // Lost conflict as defender
+            event.conflict.attackingPlayer === context.player.opponent &&
+            event.conflict.winner === context.player.opponent &&
+            // Equal or more broken provinces
+            this._retributionBrokenProvincesForPlayer(context.player) >=
+                this._retributionBrokenProvincesForPlayer(context.player.opponent)
+        );
+    }
+
+    _retributionAttackerFilter(card, context) {
+        return (
+            // honored or battlemaiden
+            (card.isHonored || card.hasTrait('battle-maiden')) &&
+            // can attack military
+            Object.values(this.game.rings).some(
+                (ring) => ring.canDeclare(context.player) && card.canDeclareAsAttacker(ConflictTypes.Military, ring)
+            )
+        );
+    }
+
+    _retributionBrokenProvincesForPlayer(player) {
+        const gameModeProvinceCount = this.game.gameMode === GameModes.Skirmish ? 4 : 5;
+        const locations = [
+            Locations.StrongholdProvince,
+            Locations.ProvinceOne,
+            Locations.ProvinceTwo,
+            Locations.ProvinceThree,
+            Locations.ProvinceFour
+        ].slice(0, gameModeProvinceCount);
+        return locations.reduce(
+            (sum, location) => (player.getProvinceCardInProvince(location).isBroken ? sum + 1 : sum),
+            0
+        );
+    }
+}
+
+Retribution.id = 'retribution-';
+
+module.exports = Retribution;

--- a/server/game/cards/19.1-AS01/Unicorn/ShinjoArcher.js
+++ b/server/game/cards/19.1-AS01/Unicorn/ShinjoArcher.js
@@ -1,0 +1,59 @@
+const DrawCard = require('../../../drawcard.js');
+const { TargetModes, CardTypes, Durations } = require('../../../Constants');
+const AbilityDsl = require('../../../abilitydsl');
+
+const shinjoArcherCost = function () {
+    return {
+        canPay: function (context) {
+            const canMoveHome = context.game.actions.sendHome().canAffect(context.source, context);
+            const canMoveToConflict = context.game.actions.moveToConflict().canAffect(context.source, context);
+
+            return canMoveHome || canMoveToConflict;
+        },
+        getActionName(context) { // eslint-disable-line no-unused-vars
+            return 'shinjoArcherCost';
+        },
+        getCostMessage: (context) => {
+            if(!context.source.isParticipating()) {
+                return ['moving {1} home', [context.source]];
+            }
+            return ['moving {1} to the conflict', [context.source]];
+        },
+        resolve: function (context, result) { // eslint-disable-line no-unused-vars
+            context.costs.shinjoArcherCost = context.source;
+        },
+        payEvent: function (context) {
+            let action = context.game.actions.moveToConflict({ target: context.costs.shinjoArcherCost });
+            if(context.source.isParticipating()) {
+                action = context.game.actions.sendHome({ target: context.costs.shinjoArcherCost });
+            }
+            return action.getEvent(context.costs.shinjoArcherCost, context);
+        },
+        promptsPlayer: false
+    };
+};
+
+class ShinjoArcher extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Move and give -2/-2',
+            condition: context => context.game.isDuringConflict(),
+            cost: shinjoArcherCost(),
+            target: {
+                mode: TargetModes.Single,
+                cardType: CardTypes.Character,
+                cardCondition: card => card.isParticipating(),
+                gameAction: AbilityDsl.actions.cardLastingEffect(() => ({
+                    effect: AbilityDsl.effects.modifyBothSkills(-2),
+                    duration: Durations.UntilEndOfConflict
+                }))
+            },
+            effect: 'give {0} -2{2}/-2{3}',
+            effectArgs: context => [context.source, 'military', 'political']
+        });
+    }
+}
+
+ShinjoArcher.id = 'shinjo-archer';
+
+module.exports = ShinjoArcher;

--- a/server/game/cards/19.1-AS01/Unicorn/UtakuTakeko.js
+++ b/server/game/cards/19.1-AS01/Unicorn/UtakuTakeko.js
@@ -1,0 +1,119 @@
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, EventNames, Locations, Players, PlayTypes, TargetModes } = require('../../../Constants');
+const DrawCard = require('../../../drawcard.js');
+const EventRegistrar = require('../../../eventregistrar.js');
+const PlayCharacterAction = require('../../../playcharacteraction.js');
+const PlayDisguisedCharacterAction = require('../../../PlayDisguisedCharacterAction.js');
+
+class UtakuTakekoPlayAction extends PlayCharacterAction {
+    constructor(card) {
+        super(card, false, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location')
+            ? ignoredRequirements
+            : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+class UtakuTakekoPlayDisguisedAction extends PlayDisguisedCharacterAction {
+    constructor(card) {
+        super(card, false, true);
+    }
+
+    createContext(player = this.card.controller) {
+        const context = super.createContext(player);
+        context.playType = PlayTypes.PlayFromHand;
+        return context;
+    }
+
+    meetsRequirements(context, ignoredRequirements = []) {
+        let newIgnoredRequirements = ignoredRequirements.includes('location')
+            ? ignoredRequirements
+            : ignoredRequirements.concat('location');
+        return super.meetsRequirements(context, newIgnoredRequirements);
+    }
+}
+
+class UtakuTakeko extends DrawCard {
+    setupCardAbilities() {
+        this.charactersLeftPlayThisPhase = new Set();
+        this.eventRegistrar = new EventRegistrar(this.game, this);
+        this.eventRegistrar.register([EventNames.OnPhaseStarted, EventNames.OnCardLeavesPlay]);
+
+        this.action({
+            title: 'Play character from your discard pile',
+            target: {
+                location: Locations.DynastyDiscardPile,
+                mode: TargetModes.Single,
+                cardType: CardTypes.Character,
+                controller: Players.Self,
+                cardCondition: (card) =>
+                    card.glory >= 1 &&
+                    card.isFaction('unicorn') &&
+                    !card.isUnique() &&
+                    !this.charactersLeftPlayThisPhase.has(card.name),
+                gameAction: AbilityDsl.actions.sequential([
+                    AbilityDsl.actions.cardLastingEffect((context) => ({
+                        target: context.target,
+                        effect: [
+                            AbilityDsl.effects.gainPlayAction(UtakuTakekoPlayAction),
+                            AbilityDsl.effects.gainPlayAction(UtakuTakekoPlayDisguisedAction)
+                        ]
+                    })),
+                    AbilityDsl.actions.playCard((context) => ({
+                        target: context.target
+                    }))
+                ])
+            },
+            effect: 'recall a {1} relative who is {2} {3}',
+            effectArgs: (context) => [
+                this._takekoDistanceMsg(context.target),
+                this._takekoConnectiveForName(context.target),
+                context.target
+            ]
+        });
+    }
+
+    _takekoDistanceMsg(card) {
+        return card.hasTrait('gaijin') ? 'very distant' : 'distant';
+    }
+
+    _takekoConnectiveForName(card) {
+        if(card.hasTrait('army')) {
+            return 'in the';
+        }
+
+        switch(card.name[0]) {
+            case 'A':
+            case 'E':
+            case 'I':
+            case 'O':
+            case 'U':
+                return 'an';
+            default:
+                return 'a';
+        }
+    }
+
+    onPhaseStarted() {
+        this.charactersLeftPlayThisPhase.clear();
+    }
+
+    onCardLeavesPlay(event) {
+        if(event.card.type === CardTypes.Character && event.card.controller === this.controller) {
+            this.charactersLeftPlayThisPhase.add(event.card.name);
+        }
+    }
+}
+
+UtakuTakeko.id = 'utaku-takeko';
+
+module.exports = UtakuTakeko;

--- a/server/game/cards/19.1-AS01/Unicorn/WhispersOfTheLordsOfDeath.js
+++ b/server/game/cards/19.1-AS01/Unicorn/WhispersOfTheLordsOfDeath.js
@@ -1,0 +1,44 @@
+const DrawCard = require('../../../drawcard.js');
+const AbilityDsl = require('../../../abilitydsl');
+const { CardTypes, Players, FavorTypes, Locations } = require('../../../Constants.js');
+
+class WhispersOfTheLordsOfDeath extends DrawCard {
+    setupCardAbilities() {
+        this.persistentEffect({
+            targetController: Players.Any,
+            effect: AbilityDsl.effects.changePlayerGloryModifier((player) => this._whispersGloryCountBonus(player))
+        });
+
+        this.reaction({
+            title: 'Put into play',
+            location: [Locations.Hand],
+            when: {
+                onCardLeavesPlay: (event, context) =>
+                    event.card.type === CardTypes.Character && context.game.isDuringConflict()
+            },
+            gameAction: AbilityDsl.actions.multiple([
+                AbilityDsl.actions.putIntoPlay((context) => ({ target: context.source })),
+                AbilityDsl.actions.claimImperialFavor((context) => ({
+                    target: context.player,
+                    side: FavorTypes.Military
+                }))
+            ]),
+            effect: 'put {0} into play and claim the Imperial Favor'
+        });
+    }
+
+    _whispersGloryCountBonus(player) {
+        return player.cardsInPlay.reduce((maxMil, card) => {
+            if(card.type !== CardTypes.Character) {
+                return maxMil;
+            }
+
+            let cardMil = card.getMilitarySkill();
+            return cardMil > maxMil ? cardMil : maxMil;
+        }, 0);
+    }
+}
+
+WhispersOfTheLordsOfDeath.id = 'whispers-of-the-lords-of-death';
+
+module.exports = WhispersOfTheLordsOfDeath;

--- a/server/game/cards/Soldier.ts
+++ b/server/game/cards/Soldier.ts
@@ -1,8 +1,9 @@
-const DrawCard = require('../drawcard.js');
-const { Locations, CardTypes } = require('../Constants');
+import { CardTypes, Locations } from '../Constants';
+import DrawCard = require('../drawcard');
+import Player = require('../player');
 
-class Soldier extends DrawCard {
-    constructor(facedownCard) {
+export default class Soldier<D extends DrawCard> extends DrawCard {
+    constructor(facedownCard: D) {
         super(facedownCard.owner, {
             clan: 'neutral',
             cost: null,
@@ -23,8 +24,8 @@ class Soldier extends DrawCard {
         this.facedownCard = facedownCard;
     }
 
-    leavesPlay() {
-        this.owner.moveCard(this.facedownCard, Locations.ConflictDiscardPile);
+    leavesPlay(destination = Locations.ConflictDiscardPile): void {
+        this.owner.moveCard(this.facedownCard, destination);
         this.game.queueSimpleStep(() => {
             this.owner.removeCardFromPile(this);
             this.game.allCards = this.owner.removeCardByUuid(this.game.allCards, this.uuid);
@@ -32,14 +33,12 @@ class Soldier extends DrawCard {
         super.leavesPlay();
     }
 
-    getSummary(activePlayer, hideWhenFaceup) {
-        let summary = super.getSummary(activePlayer, hideWhenFaceup);
-        let tokenProps = { isToken: true };
-        if(activePlayer === this.controller) {
-            tokenProps.id = this.facedownCard.cardData.id;
-        }
+    getSummary(activePlayer: Player, hideWhenFaceup: boolean) {
+        const summary = super.getSummary(activePlayer, hideWhenFaceup);
+        const tokenProps = {
+            isToken: true,
+            id: activePlayer === this.controller ? this.facedownCard.cardData.id : undefined
+        };
         return Object.assign(summary, tokenProps);
     }
 }
-
-module.exports = Soldier;

--- a/server/game/conflict.js
+++ b/server/game/conflict.js
@@ -375,7 +375,7 @@ class Conflict extends GameObject {
             if(cannotContribute) {
                 return sum;
             }
-            return sum + skillFunction(card);
+            return sum + skillFunction(card, this);
         }, 0);
     }
 
@@ -433,6 +433,10 @@ class Conflict extends GameObject {
         this.game.currentConflict = null;
         this.game.raiseEvent(EventNames.OnConflictPass, { conflict: this });
         this.resetCards();
+    }
+
+    isBreaking() {
+        return this.conflictProvince && (this.getConflictProvinces().some(p => p.getStrength() - (this.attackerSkill - this.defenderSkill) <= 0));
     }
 }
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -26,6 +26,14 @@ const Costs = {
      */
     bow: properties => getSelectCost(GameActions.bow(), properties, 'Select card to bow'),
     /**
+     * Cost that will move home the card that initiated the ability.
+     */
+    moveHomeSelf: () => new GameActionCost(GameActions.sendHome(context => ({target: context.source}))),
+    /**
+     * Cost that will send the target to the conflict.
+     */
+    moveToConflict: properties => getSelectCost(GameActions.moveToConflict(), properties, 'Select card to move to the conflict'),
+    /**
      * Cost that will sacrifice the card that initiated the ability.
      */
     sacrificeSelf: () => new GameActionCost(GameActions.sacrifice()),
@@ -65,6 +73,10 @@ const Costs = {
      * Cost that requires discarding a specific card.
      */
     discardCardSpecific: cardFunc => new GameActionCost(GameActions.discardCard(context => ({ target: cardFunc(context) }))),
+    /**
+     * Cost that requires discarding itself from hand.
+     */
+    discardSelf: () => new GameActionCost(GameActions.discardCard(context => ({ target: context.source }))),
     /**
      * Cost that requires discarding a card to be selected by the player.
      */

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -306,13 +306,22 @@ class DrawCard extends BaseCard {
         };
     }
 
-    getMilitaryModifiers(exclusions = []) {
+    getMilitaryModifiers(exclusions) {
         let baseSkillModifiers = this.getBaseSkillModifiers();
         if(isNaN(baseSkillModifiers.baseMilitarySkill)) {
             return baseSkillModifiers.baseMilitaryModifiers;
         }
 
-        let rawEffects = this.getRawEffects().filter(effect => !exclusions.includes(effect.type));
+        if(!exclusions) {
+            exclusions = [];
+        }
+
+        let rawEffects;
+        if(typeof exclusions === 'function') {
+            rawEffects = this.getRawEffects().filter(effect => !exclusions(effect));
+        } else {
+            rawEffects = this.getRawEffects().filter(effect => !exclusions.includes(effect.type));
+        }
 
         // set effects
         let setEffects = rawEffects.filter(effect => effect.type === EffectNames.SetMilitarySkill || effect.type === EffectNames.SetDash);
@@ -346,13 +355,22 @@ class DrawCard extends BaseCard {
         return modifiers;
     }
 
-    getPoliticalModifiers(exclusions = []) {
+    getPoliticalModifiers(exclusions) {
         let baseSkillModifiers = this.getBaseSkillModifiers();
         if(isNaN(baseSkillModifiers.basePoliticalSkill)) {
             return baseSkillModifiers.basePoliticalModifiers;
         }
 
-        let rawEffects = this.getRawEffects().filter(effect => !exclusions.includes(effect.type));
+        if(!exclusions) {
+            exclusions = [];
+        }
+
+        let rawEffects;
+        if(typeof exclusions === 'function') {
+            rawEffects = this.getRawEffects().filter(effect => !exclusions(effect));
+        } else {
+            rawEffects = this.getRawEffects().filter(effect => !exclusions.includes(effect.type));
+        }
 
         // set effects
         let setEffects = rawEffects.filter(effect => effect.type === EffectNames.SetPoliticalSkill);
@@ -575,7 +593,7 @@ class DrawCard extends BaseCard {
     }
 
     getMilitarySkillExcludingModifiers(exclusions, floor = true) {
-        if(!Array.isArray(exclusions)) {
+        if(!Array.isArray(exclusions) && typeof exclusions !== 'function') {
             exclusions = [exclusions];
         }
         let modifiers = this.getMilitaryModifiers(exclusions);
@@ -600,10 +618,10 @@ class DrawCard extends BaseCard {
     }
 
     getPoliticalSkillExcludingModifiers(exclusions, floor = true) {
-        if(!Array.isArray(exclusions)) {
+        if(!Array.isArray(exclusions) && typeof exclusions !== 'function') {
             exclusions = [exclusions];
         }
-        let modifiers = this.getPoliticalModifiers();
+        let modifiers = this.getPoliticalModifiers(exclusions);
         let skill = modifiers.reduce((total, modifier) => total + modifier.amount, 0);
         if(isNaN(skill)) {
             return 0;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -23,6 +23,7 @@ const Effects = {
     addKeyword: (keyword) => EffectBuilder.card.static(EffectNames.AddKeyword, keyword),
     addTrait: (trait) => EffectBuilder.card.static(EffectNames.AddTrait, trait),
     additionalTriggerCostForCard: (func) => EffectBuilder.card.static(EffectNames.AdditionalTriggerCost, func),
+    attachmentCardCondition: (func) => EffectBuilder.card.static(EffectNames.AttachmentCardCondition, func),
     attachmentFactionRestriction: (factions) => EffectBuilder.card.static(EffectNames.AttachmentFactionRestriction, factions),
     attachmentLimit: (amount) => EffectBuilder.card.static(EffectNames.AttachmentLimit, amount),
     attachmentMyControlOnly: () => EffectBuilder.card.static(EffectNames.AttachmentMyControlOnly),
@@ -96,6 +97,7 @@ const Effects = {
     legendaryFate: (amount = 1) => EffectBuilder.card.flexible(EffectNames.LegendaryFate, amount),
     loseAllNonKeywordAbilities: () => EffectBuilder.card.static(EffectNames.LoseAllNonKeywordAbilities),
     loseKeyword: (keyword) => EffectBuilder.card.static(EffectNames.LoseKeyword, keyword),
+    loseTrait: (trait) => EffectBuilder.card.static(EffectNames.LoseTrait, trait),
     modifyBaseMilitarySkillMultiplier: (value) => EffectBuilder.card.flexible(EffectNames.ModifyBaseMilitarySkillMultiplier, value),
     modifyBasePoliticalSkillMultiplier: (value) => EffectBuilder.card.flexible(EffectNames.ModifyBasePoliticalSkillMultiplier, value),
     modifyBaseProvinceStrength: (value) => EffectBuilder.card.flexible(EffectNames.ModifyBaseProvinceStrength, value),
@@ -211,7 +213,7 @@ const Effects = {
     modifyHonorTransferGiven: (amount) => EffectBuilder.player.static(EffectNames.ModifyHonorTransferGiven, amount),
     modifyHonorTransferReceived: (amount) => EffectBuilder.player.static(EffectNames.ModifyHonorTransferReceived, amount),
     cannotResolveRings: () => EffectBuilder.player.static(EffectNames.CannotResolveRings),
-    changePlayerGloryModifier: (value) => EffectBuilder.player.static(EffectNames.ChangePlayerGloryModifier, value),
+    changePlayerGloryModifier: (value) => EffectBuilder.player.flexible(EffectNames.ChangePlayerGloryModifier, value),
     changePlayerSkillModifier: (value) => EffectBuilder.player.flexible(EffectNames.ChangePlayerSkillModifier, value),
     customDetachedPlayer: (properties) => EffectBuilder.player.detached(EffectNames.CustomEffect, properties),
     gainActionPhasePriority: () => EffectBuilder.player.detached(EffectNames.GainActionPhasePriority, {
@@ -222,6 +224,7 @@ const Effects = {
     modifyCardsDrawnInDrawPhase: (amount) => EffectBuilder.player.flexible(EffectNames.ModifyCardsDrawnInDrawPhase, amount),
     playerCannot: (properties) => EffectBuilder.player.static(EffectNames.AbilityRestrictions, new Restriction(Object.assign({ type: properties.cannot || properties }, properties))),
     playerDelayedEffect: (properties) => EffectBuilder.player.static(EffectNames.DelayedEffect, properties),
+    playerFateCostToTargetCard: (properties) => EffectBuilder.player.flexible(EffectNames.PlayerFateCostToTargetCard, properties), /* amount: number; match: (card) => boolean */
     reduceCost: (properties) => EffectBuilder.player.detached(EffectNames.CostReducer, {
         apply: (player, context) => player.addCostReducer(context.source, properties),
         unapply: (player, context, reducer) => player.removeCostReducer(reducer)
@@ -255,6 +258,7 @@ const Effects = {
     restrictNumberOfDefenders: (value) => EffectBuilder.conflict.static(EffectNames.RestrictNumberOfDefenders, value), // TODO: Add this to lasting effect checks
     resolveConflictEarly: () => EffectBuilder.player.static(EffectNames.ResolveConflictEarly),
     forceConflictUnopposed: () => EffectBuilder.conflict.static(EffectNames.ForceConflictUnopposed),
+    modifyUnopposedHonorLoss: (amount = 1) => EffectBuilder.conflict.static(EffectNames.ModifyUnopposedHonorLoss, amount),
     additionalAttackedProvince: (province) => EffectBuilder.conflict.static(EffectNames.AdditionalAttackedProvince, province),
     conflictIgnoreStatusTokens: () => EffectBuilder.conflict.static(EffectNames.ConflictIgnoreStatusTokens)
 };

--- a/server/game/gamesteps/conflict/conflictflow.js
+++ b/server/game/gamesteps/conflict/conflictflow.js
@@ -602,8 +602,11 @@ class ConflictFlow extends BaseStepWithPipeline {
         }
 
         if(this.conflict.conflictUnopposed) {
-            this.game.addMessage('{0} loses 1 honor for not defending the conflict', this.conflict.loser);
-            GameActions.loseHonor({ dueToUnopposed: true }).resolve(this.conflict.loser, this.game.getFrameworkContext(this.conflict.loser));
+            let honorLossMods = this.conflict.sumEffects(EffectNames.ModifyUnopposedHonorLoss);
+
+            const honorLoss = Math.max(0, 1 + honorLossMods);
+            this.game.addMessage('{0} loses {1} honor for not defending the conflict', this.conflict.loser, honorLoss);
+            GameActions.loseHonor({ dueToUnopposed: true, amount: honorLoss }).resolve(this.conflict.loser, this.game.getFrameworkContext(this.conflict.loser));
         }
     }
 

--- a/server/game/gamesteps/fatephase.js
+++ b/server/game/gamesteps/fatephase.js
@@ -89,12 +89,11 @@ class FatePhase extends Phase {
         if(this.game.gameMode === GameModes.Skirmish) {
             return;
         }
-        this.game.raiseEvent(EventNames.OnPlaceFateOnUnclaimedRings, {}, () => {
-            _.each(this.game.rings, ring => {
-                if(ring.isUnclaimed()) {
-                    ring.modifyFate(1);
-                }
-            });
+        let recipients = Object.values(this.game.rings)
+            .filter((ring) => ring.isUnclaimed())
+            .map((ring) => ({ ring: ring, amount: 1 }));
+        this.game.raiseEvent(EventNames.OnPlaceFateOnUnclaimedRings, { recipients: recipients }, () => {
+            recipients.forEach((recipient) => recipient.ring.modifyFate(recipient.amount));
         });
     }
 

--- a/server/game/playcharacteraction.js
+++ b/server/game/playcharacteraction.js
@@ -5,12 +5,13 @@ const { EffectNames, Phases, PlayTypes, EventNames, Players, Locations } = requi
 const GameModes = require('../GameModes');
 
 class PlayCharacterAction extends BaseAction {
-    constructor(card, intoConflictOnly = false) {
+    constructor(card, intoConflictOnly = false, intoPlayOnly = false) {
         super(card, [
             Costs.chooseFate(PlayTypes.PlayFromHand),
             Costs.payReduceableFateCost()
         ]);
         this.intoConflictOnly = intoConflictOnly;
+        this.intoPlayOnly = intoPlayOnly;
         this.title = 'Play this character';
     }
 
@@ -60,7 +61,7 @@ class PlayCharacterAction extends BaseAction {
             context.game.addMessage('{0} plays {1} into the conflict with {2} additional fate', context.player, context.source, context.chooseFate);
             context.game.openEventWindow([GameActions.putIntoConflict({ fate: context.chooseFate }).getEvent(context.source, context), cardPlayedEvent]);
         };
-        if(context.source.allowGameAction('putIntoConflict', context)) {
+        if(context.source.allowGameAction('putIntoConflict', context) && !this.intoPlayOnly) {
             if(this.intoConflictOnly) {
                 putIntoConflictHandler();
             } else {

--- a/test/server/cards/14.3-IPoT/ReturnFromShadows.spec.js
+++ b/test/server/cards/14.3-IPoT/ReturnFromShadows.spec.js
@@ -221,7 +221,7 @@ describe('Return From Shadows', function() {
             this.player1.clickCard(this.returnFromShadows);
             this.player1.clickCard(this.manicured);
 
-            expect(this.getChatLogs(10)).toContain('player1 plays Return From Shadows to place a dishonor token on province 2, blanking it');
+            expect(this.getChatLogs(10)).toContain('player1 plays Return From Shadows to place a dishonored status token on province 2, blanking it');
             expect(this.getChatLogs(10)).toContain('player1 reveals Manicured Garden due to Return From Shadows');
         });
 
@@ -237,7 +237,7 @@ describe('Return From Shadows', function() {
             this.player1.clickCard(this.returnFromShadows);
             this.player1.clickCard(this.pilgrimage);
 
-            expect(this.getChatLogs(10)).toContain('player1 plays Return From Shadows to place a dishonor token on Pilgrimage, blanking it');
+            expect(this.getChatLogs(10)).toContain('player1 plays Return From Shadows to place a dishonored status token on Pilgrimage, blanking it');
             expect(this.getChatLogs(10)).not.toContain('player1 reveals Pilgrimage due to Return From Shadows');
         });
 

--- a/test/server/cards/15.4-TToTS/MeticulousScout.spec.js
+++ b/test/server/cards/15.4-TToTS/MeticulousScout.spec.js
@@ -212,7 +212,7 @@ describe('Meticulous Scout', function() {
             this.player1.clickCard(this.scout);
             this.player1.clickCard(this.khan);
 
-            expect(this.getChatLogs(10)).toContain('player1 uses Meticulous Scout to place a dishonor token on province 1, blanking it');
+            expect(this.getChatLogs(10)).toContain('player1 uses Meticulous Scout to place a dishonored status token on province 1, blanking it');
             expect(this.getChatLogs(10)).toContain('player1 reveals Khan\'s Ordu due to Meticulous Scout');
         });
 
@@ -229,7 +229,7 @@ describe('Meticulous Scout', function() {
             this.player1.clickCard(this.scout);
             this.player1.clickCard(this.pilgrimage);
 
-            expect(this.getChatLogs(10)).toContain('player1 uses Meticulous Scout to place a dishonor token on Pilgrimage, blanking it');
+            expect(this.getChatLogs(10)).toContain('player1 uses Meticulous Scout to place a dishonored status token on Pilgrimage, blanking it');
             expect(this.getChatLogs(10)).not.toContain('player1 reveals Pilgrimage due to Meticulous Scout');
         });
 

--- a/test/server/cards/15.5-CoP/Overrun.spec.js
+++ b/test/server/cards/15.5-CoP/Overrun.spec.js
@@ -132,7 +132,7 @@ describe('Overrun', function() {
             this.player1.clickCard(this.overrun);
             this.player1.clickCard(this.manicured);
 
-            expect(this.getChatLogs(10)).toContain('player1 plays Overrun to place a dishonor token on province 2, blanking it');
+            expect(this.getChatLogs(10)).toContain('player1 plays Overrun to place a dishonored status token on province 2, blanking it');
             expect(this.getChatLogs(10)).toContain('player1 reveals Manicured Garden due to Overrun');
         });
 
@@ -149,7 +149,7 @@ describe('Overrun', function() {
             this.player1.clickCard(this.overrun);
             this.player1.clickCard(this.pilgrimage);
 
-            expect(this.getChatLogs(10)).toContain('player1 plays Overrun to place a dishonor token on Pilgrimage, blanking it');
+            expect(this.getChatLogs(10)).toContain('player1 plays Overrun to place a dishonored status token on Pilgrimage, blanking it');
             expect(this.getChatLogs(10)).not.toContain('player1 reveals Pilgrimage due to Overrun');
         });
     });

--- a/test/server/cards/19.1-AS01/Crab/BloodthirstyOnryo.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/BloodthirstyOnryo.spec.js
@@ -1,0 +1,81 @@
+describe('Bloodthirsty Onryō', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-diplomat', 'student-of-anatomies'],
+                    hand: ['assassination', 'cloud-the-mind'],
+                    dynastyDiscard: ['bloodthirsty-onryo']
+                }
+            });
+
+            this.student = this.player1.findCardByName('student-of-anatomies');
+            this.diplomat = this.player1.findCardByName('doji-diplomat');
+            this.onryo = this.player1.findCardByName('bloodthirsty-onryo');
+            this.assassination = this.player1.findCardByName('assassination');
+            this.cloud = this.player1.findCardByName('cloud-the-mind');
+        });
+
+        it('should sacrifice someone to be put into play from discard pile', function () {
+            this.player1.clickCard(this.onryo);
+            this.player1.clickCard(this.diplomat);
+            expect(this.onryo.location).toBe('play area');
+            expect(this.onryo.isTainted).toBe(true);
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Bloodthirsty Onryō, sacrificing Doji Diplomat to put Bloodthirsty Onryō into play'
+            );
+        });
+
+        it('should sacrifice someone to be put into play from province', function () {
+            this.player1.moveCard(this.onryo, 'province 1');
+            this.game.checkGameState(true);
+            this.player1.clickCard(this.onryo);
+            this.player1.clickCard(this.diplomat);
+            expect(this.onryo.location).toBe('play area');
+            expect(this.onryo.isTainted).toBe(true);
+        });
+
+        it('should remove from game when it leaves play', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: []
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.onryo);
+            this.player1.clickCard(this.diplomat);
+            expect(this.onryo.location).toBe('play area');
+            expect(this.onryo.isParticipating()).toBe(false);
+            this.player2.pass();
+            this.player1.clickCard(this.assassination);
+            this.player1.clickCard(this.onryo);
+            expect(this.onryo.location).toBe('removed from game');
+            expect(this.getChatLogs(5)).toContain('Bloodthirsty Onryō is removed from the game due to leaving play');
+        });
+
+        it('should remove from game even if blanked', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: []
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.onryo);
+            this.player1.clickCard(this.diplomat);
+            expect(this.onryo.location).toBe('play area');
+            expect(this.onryo.isParticipating()).toBe(false);
+            this.player2.pass();
+            this.player1.clickCard(this.student);
+            this.player1.clickCard(this.onryo);
+            this.player1.clickCard(this.student);
+            this.player2.pass();
+            this.player1.clickCard(this.assassination);
+            this.player1.clickCard(this.onryo);
+            expect(this.onryo.location).toBe('removed from game');
+            expect(this.getChatLogs(5)).toContain('Bloodthirsty Onryō is removed from the game due to leaving play');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crab/BrokenBlades.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/BrokenBlades.spec.js
@@ -1,0 +1,84 @@
+describe('Broken Blades', function () {
+    integration(function () {
+        describe('Broken Blades\'s ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['one-of-the-forgotten', 'kaiu-envoy'],
+                        hand: ['broken-blades']
+                    },
+                    player2: {
+                        inPlay: ['doji-challenger'],
+                        fate: 10
+                    }
+                });
+
+                this.oneOfTheForgotten = this.player1.findCardByName('one-of-the-forgotten');
+                this.kaiuEnvoy = this.player1.findCardByName('kaiu-envoy');
+
+                this.dojiChallenger = this.player2.findCardByName('doji-challenger');
+                this.dojiChallenger.fate = 2;
+
+                this.brokenBlades = this.player1.findCardByName('broken-blades');
+            });
+
+            it('should not trigger if there are no participating characters', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.oneOfTheForgotten, this.kaiuEnvoy],
+                    defenders: []
+                });
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Break Shameful Display');
+            });
+
+            it('does not trigger after you win a military conflict as defender', function () {
+                this.noMoreActions();
+                this.player1.passConflict();
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.dojiChallenger],
+                    defenders: [this.oneOfTheForgotten, this.kaiuEnvoy]
+                });
+
+                this.player1.pass();
+                this.player2.pass();
+
+                expect(this.player1).not.toHavePrompt('Any reactions?');
+                expect(this.player1).toHavePrompt('Initiate an action');
+            });
+
+            it('should trigger after you win a military conflict as attacker', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.oneOfTheForgotten, this.kaiuEnvoy],
+                    defenders: [this.dojiChallenger]
+                });
+                this.player2.pass();
+                this.player1.pass();
+                expect(this.player1).toBeAbleToSelect(this.brokenBlades);
+
+                this.player1.clickCard(this.brokenBlades);
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.dojiChallenger);
+                expect(this.player1).not.toBeAbleToSelect(this.oneOfTheForgotten);
+                expect(this.player1).not.toBeAbleToSelect(this.kaiuEnvoy);
+
+                this.player1.clickCard(this.dojiChallenger);
+                expect(this.player1).toHavePrompt('Select card to sacrifice');
+
+                this.player1.clickCard(this.oneOfTheForgotten);
+                expect(this.getChatLogs(1)).toContain(
+                    'player1 plays Broken Blades, sacrificing One of the Forgotten to ensure Doji Challenger is gone! (player2 recovers 2 fate)'
+                );
+                expect(this.player2.fate).toBe(12);
+                expect(this.dojiChallenger.location).toBe('dynasty discard pile');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crab/CinderSalamander.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/CinderSalamander.spec.js
@@ -1,0 +1,143 @@
+describe('Cinder Salamander', function () {
+    integration(function () {
+        describe('Cinder Salamander Reaction Ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['cinder-salamander'],
+                        hand: ['way-of-the-crab']
+                    },
+                    player2: {
+                        inPlay: ['moto-chagatai'],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.cinderSalamander = this.player1.findCardByName('cinder-salamander');
+                this.wayOfTheCrab = this.player1.findCardByName('way-of-the-crab');
+
+                this.chagatai = this.player2.findCardByName('moto-chagatai');
+                this.assassination = this.player2.findCardByName('assassination');
+            });
+
+            it('shuffles itself back into the deck after being sacrificed', function () {
+                this.player1.clickCard(this.wayOfTheCrab);
+                this.player1.clickCard(this.cinderSalamander);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.cinderSalamander);
+                this.player1.clickCard(this.cinderSalamander);
+
+                expect(this.cinderSalamander.location).toBe('dynasty deck');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Cinder Salamander to shuffle Cinder Salamander into player1\'s dynasty deck'
+                );
+
+                this.player2.clickCard(this.chagatai);
+                expect(this.chagatai.location).toBe('dynasty discard pile');
+            });
+
+            it('shuffles itself back into the deck after being discarded from play', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.cinderSalamander],
+                    defenders: [this.chagatai]
+                });
+
+                this.player2.clickCard(this.assassination);
+                this.player2.clickCard(this.cinderSalamander);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.cinderSalamander);
+
+                this.player1.clickCard(this.cinderSalamander);
+                expect(this.cinderSalamander.location).toBe('dynasty deck');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Cinder Salamander to shuffle Cinder Salamander into player1\'s dynasty deck'
+                );
+            });
+        });
+
+        describe('Cinder Salamander Action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['cinder-salamander', 'cinder-salamander', 'cinder-salamander']
+                    }
+                });
+
+                let salamanders = this.player1.filterCardsByName('cinder-salamander');
+                this.salamander1 = salamanders[0];
+                this.salamander2 = salamanders[1];
+                this.salamander3 = salamanders[2];
+
+                this.player1.claimRing('fire');
+                this.game.checkGameState(true);
+            });
+
+            it('when 3 salamanders are in play, shuffle dynasty deck', function () {
+                this.player1.clickCard(this.salamander1);
+
+                expect(this.player1).toHavePrompt('Select characters to put into play from your deck');
+                expect(this.player1).toHavePromptButton('Take nothing');
+                this.player1.clickPrompt('Take nothing');
+                expect(this.getChatLogs(5)).toContain('player1 is shuffling their dynasty deck');
+
+                expect(this.player2).toHavePrompt('Initiate an action');
+            });
+
+            it('find all salamanders from dynasty deck and allows to put them into play', function () {
+                this.player1.player.moveCard(this.salamander2, 'dynasty deck');
+                this.player1.player.moveCard(this.salamander3, 'dynasty deck');
+
+                this.player1.clickCard(this.salamander1);
+                expect(this.getChatLogs(5)).toContain('player1 uses Cinder Salamander to search their deck and provinces for other copies of Cinder Salamander and put them into play');
+                expect(this.player1).toHavePrompt('Select characters to put into play from your deck');
+                expect(this.player1).toHavePromptButton('Cinder Salamander (2)');
+
+                this.player1.clickPrompt('Cinder Salamander (2)');
+                expect(this.player1).toHavePromptButton('Cinder Salamander');
+                this.player1.clickPrompt('Cinder Salamander');
+
+                expect(this.salamander1.location).toBe('play area');
+                expect(this.salamander2.location).toBe('play area');
+                expect(this.salamander3.location).toBe('play area');
+
+                expect(this.getChatLogs(5)).toContain('player1 finds 2 salamanders in their deck');
+                expect(this.getChatLogs(5)).toContain('player1 is shuffling their dynasty deck');
+
+                expect(this.player2).toHavePrompt('Initiate an action');
+            });
+
+            it('find all salamanders from provinces and allows to put them into play', function () {
+                this.player1.placeCardInProvince(this.salamander2, 'province 2');
+                this.player1.placeCardInProvince(this.salamander3, 'province 3');
+                this.salamander3.facedown = true;
+
+                this.player1.clickCard(this.salamander1);
+                this.player1.clickPrompt('Take nothing');
+                expect(this.getChatLogs(5)).toContain('player1 uses Cinder Salamander to search their deck and provinces for other copies of Cinder Salamander and put them into play');
+                expect(this.getChatLogs(5)).toContain('player1 finds no salamanders in their deck');
+
+                expect(this.player1).toHavePrompt('Select characters to put into play from your provinces');
+                expect(this.player1).toBeAbleToSelect(this.salamander2);
+                expect(this.player1).not.toBeAbleToSelect(this.salamander3);
+
+                this.player1.clickCard(this.salamander2);
+                expect(this.player1).toHavePromptButton('Done');
+
+                this.player1.clickPrompt('Done');
+                expect(this.salamander1.location).toBe('play area');
+                expect(this.salamander2.location).toBe('play area');
+                expect(this.salamander3.location).toBe('province 3');
+
+                expect(this.getChatLogs(5)).toContain('player1 finds 1 salamander in their provinces');
+
+                expect(this.player2).toHavePrompt('Initiate an action');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crab/EarnestSculptor.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/EarnestSculptor.spec.js
@@ -1,0 +1,148 @@
+describe('Earnest Sculptor', function () {
+    integration(function () {
+        describe('Constant ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        fate: 1,
+                        inPlay: ['earnest-sculptor'],
+                        hand: ['jade-talisman', 'jade-strike', 'finger-of-jade', 'jade-tetsubo']
+                    },
+                    player2: {
+                        inPlay: ['goblin-sneak']
+                    }
+                });
+
+                this.earnestSculptor = this.player1.findCardByName('earnest-sculptor');
+                this.fingerOfJade = this.player1.findCardByName('finger-of-jade');
+                this.jadeStrike = this.player1.findCardByName('jade-strike');
+
+                this.goblinSneakTainted = this.player2.findCardByName('goblin-sneak');
+                this.goblinSneakTainted.taint();
+            });
+
+            it('allows players to pay 0 cost cards with 0 fate', function () {
+                this.player1.fate = 0;
+                this.jadeTalisman = this.player1.playAttachment('jade-talisman', this.earnestSculptor);
+                expect(this.player1).not.toHavePrompt('Triggered Abilities');
+                expect(this.jadeTalisman.location).toBe('play area');
+            });
+
+            it('allows players to pay 1 cost cards with 0 fate', function () {
+                this.player1.fate = 0;
+
+                this.player1.clickCard(this.fingerOfJade);
+                this.player1.clickCard(this.earnestSculptor);
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.earnestSculptor);
+
+                this.player1.clickCard(this.earnestSculptor);
+                expect(this.fingerOfJade.location).toBe('play area');
+                expect(this.player1.fate).toBe(0);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Earnest Sculptor to reduce the cost of Finger of Jade by 1'
+                );
+            });
+
+            it('allows players to pay 2 cost cards with 1 fate', function () {
+                this.player1.fate = 1;
+                this.jadeTetsubo = this.player1.playAttachment('jade-tetsubo', this.earnestSculptor);
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.earnestSculptor);
+
+                this.player1.clickCard(this.earnestSculptor);
+                expect(this.jadeTetsubo.location).toBe('play area');
+                expect(this.player1.fate).toBe(0);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Earnest Sculptor to reduce the cost of Jade Tetsubō by 1'
+                );
+            });
+
+            it('allows playing events with discount', function () {
+                this.player1.fate = 0;
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.earnestSculptor],
+                    defenders: [this.goblinSneakTainted]
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.jadeStrike);
+                expect(this.player1).toHavePrompt('Jade Strike');
+                this.player1.clickCard(this.goblinSneakTainted);
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.earnestSculptor);
+
+                this.player1.clickCard(this.earnestSculptor);
+
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Earnest Sculptor to reduce the cost of Jade Strike by 1'
+                );
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 plays Jade Strike to remove a fate from and set the base skills of Goblin Sneak to 0military/0political'
+                );
+            });
+        });
+
+        describe('Earnest Sculptor\'s search ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['earnest-sculptor'],
+                        conflictDeck: [
+                            'hurricane-punch',
+                            'against-the-waves',
+                            'mantra-of-fire',
+                            'censure',
+                            'cloud-the-mind'
+                        ],
+                        conflictDeckSize: 5
+                    },
+                    player2: {}
+                });
+                this.earnestSculptor = this.player1.findCardByName('earnest-sculptor');
+                this.cloudTheMind = this.player1.findCardByName('cloud-the-mind');
+            });
+
+            it('should prompt to choose from the top 5 cards for a spell', function () {
+                this.player1.clickCard(this.earnestSculptor);
+                expect(this.player1).toHavePrompt('Select a card to reveal');
+                expect(this.player1).toHaveDisabledPromptButton('Hurricane Punch');
+                expect(this.player1).toHavePromptButton('Against the Waves');
+                expect(this.player1).toHaveDisabledPromptButton('Mantra of Fire');
+                expect(this.player1).toHaveDisabledPromptButton('Censure');
+                expect(this.player1).toHavePromptButton('Cloud the Mind');
+            });
+
+            it('should reveal the chosen attachment', function () {
+                this.player1.clickCard(this.earnestSculptor);
+                this.player1.clickPrompt('Cloud the Mind');
+                expect(this.getChatLogs(2)).toContain('player1 takes Cloud the Mind');
+            });
+
+            it('should add the chosen card to your hand', function () {
+                this.player1.clickCard(this.earnestSculptor);
+                this.player1.clickPrompt('Cloud the Mind');
+                expect(this.cloudTheMind.location).toBe('hand');
+            });
+
+            it('should shuffle the conflict deck', function () {
+                this.player1.clickCard(this.earnestSculptor);
+                this.player1.clickPrompt('Cloud the Mind');
+                expect(this.getChatLogs(1)).toContain('player1 is shuffling their conflict deck');
+            });
+
+            it('should allow you to choose to take nothing', function () {
+                this.player1.clickCard(this.earnestSculptor);
+                expect(this.player1).toHavePromptButton('Take nothing');
+                this.player1.clickPrompt('Take nothing');
+                expect(this.getChatLogs(2)).toContain('player1 takes nothing');
+                expect(this.getChatLogs(1)).toContain('player1 is shuffling their conflict deck');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crab/KuniJuurou.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/KuniJuurou.spec.js
@@ -1,0 +1,325 @@
+describe('Kuni Juurou', function () {
+    integration(function () {
+        describe('Static ability - no honor costs', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['kuni-juurou', 'kaiu-envoy', 'exiled-guardian'],
+                        hand: ['assassination', 'obsidian-talisman', 'banzai'],
+                        dynastyDeck: ['fire-and-oil']
+                    },
+                    player2: {
+                        inPlay: ['bayushi-manipulator'],
+                        hand: ['backhanded-compliment', 'way-of-the-scorpion', 'assassination']
+                    }
+                });
+
+                this.kuniAina = this.player1.findCardByName('kuni-juurou');
+                this.envoy = this.player1.findCardByName('kaiu-envoy');
+                this.exiledGuardian = this.player1.findCardByName('exiled-guardian');
+                this.assassinationCrab = this.player1.findCardByName('assassination');
+                this.banzai = this.player1.findCardByName('banzai');
+                this.obsidianTalisman = this.player1.findCardByName('obsidian-talisman');
+                this.fireAndOil = this.player1.findCardByName('fire-and-oil');
+                this.province1 = this.player1.findCardByName('shameful-display', 'province 1');
+
+                this.manipulator = this.player2.findCardByName('bayushi-manipulator');
+                this.bhc = this.player2.findCardByName('backhanded-compliment');
+                this.assassinationScorp = this.player2.findCardByName('assassination');
+                this.wayOfTheScorpion = this.player2.findCardByName('way-of-the-scorpion');
+            });
+
+            it('Loses honor normally due to effects', function () {
+                let player1StartingHonor = this.player1.honor;
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.kuniAina, this.envoy],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.wayOfTheScorpion);
+                this.player2.clickCard(this.envoy);
+
+                this.player1.pass();
+
+                this.player2.clickCard(this.assassinationScorp);
+                this.player2.clickCard(this.envoy);
+
+                expect(this.player1.honor).toBe(player1StartingHonor - 1);
+
+                this.player1.pass();
+
+                this.player2.clickCard(this.bhc);
+                this.player2.clickPrompt('player1');
+                expect(this.player1.honor).toBe(player1StartingHonor - 2);
+            });
+
+            it('cannot play events that cost honor', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.kuniAina, this.envoy],
+                    defenders: []
+                });
+
+                this.player2.pass();
+
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+
+                this.player1.clickCard(this.assassinationCrab);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('cannot trigger holdings that cost honor', function () {
+                this.noMoreActions();
+                this.player1.clickPrompt('Pass Conflict');
+                this.player1.clickPrompt('Yes');
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.manipulator],
+                    defenders: []
+                });
+
+                this.player1.clickCard(this.fireAndOil);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('cannot pay additional honor costs imposed by opponent', function () {
+                this.noMoreActions();
+                this.player1.clickPrompt('Pass Conflict');
+                this.player1.clickPrompt('Yes');
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.manipulator],
+                    defenders: []
+                });
+
+                this.player1.clickCard(this.fireAndOil);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('cannot declare tainted characters into conflicts', function () {
+                this.exiledGuardian.taint();
+                this.noMoreActions();
+
+                this.player1.clickCard(this.player2.provinces['province 1'].provinceCard);
+                this.player1.clickRing('fire');
+                this.player1.clickCard(this.exiledGuardian);
+                expect(this.player1).not.toHavePromptButton('Initiate Conflict');
+                this.player1.clickCard(this.envoy);
+                expect(this.player1).toHavePromptButton('Initiate Conflict');
+                this.player1.clickPrompt('Initiate Conflict');
+
+                expect(this.getChatLogs(5)).toContain('player1 has initiated a military conflict with skill 1');
+            });
+        });
+
+        describe('Static ability - skill penalty', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: [
+                            'kuni-juurou',
+                            'unleashed-experiment',
+                            'jealous-ancestor',
+                            'kaiu-envoy',
+                            'borderlands-defender'
+                        ],
+                        hand: ['lurking-affliction']
+                    },
+                    player2: {
+                        inPlay: ['unleashed-experiment', 'jealous-ancestor', 'kaiu-envoy', 'borderlands-defender'],
+                        hand: ['lurking-affliction']
+                    }
+                });
+
+                this.kuniAina = this.player1.findCardByName('kuni-juurou');
+                this.experimentP1 = this.player1.findCardByName('unleashed-experiment');
+                this.jealousP1 = this.player1.findCardByName('jealous-ancestor');
+                this.envoyP1 = this.player1.findCardByName('kaiu-envoy');
+                this.borderlandsP1 = this.player1.findCardByName('borderlands-defender');
+                this.afflictionP1 = this.player1.findCardByName('lurking-affliction');
+
+                this.experimentP2 = this.player2.findCardByName('unleashed-experiment');
+                this.jealousP2 = this.player2.findCardByName('jealous-ancestor');
+                this.envoyP2 = this.player2.findCardByName('kaiu-envoy');
+                this.borderlandsP2 = this.player2.findCardByName('borderlands-defender');
+                this.afflictionP2 = this.player2.findCardByName('lurking-affliction');
+            });
+
+            it('When Juurou is in the conflict, it gives skill penalty to shadowlands', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.kuniAina, this.experimentP1, this.jealousP1, this.envoyP1, this.borderlandsP1],
+                    defenders: [this.experimentP2, this.jealousP2, this.envoyP2, this.borderlandsP2]
+                });
+
+                this.player2.clickCard(this.afflictionP2);
+                this.player2.clickCard(this.envoyP2);
+
+                this.player1.clickCard(this.afflictionP1);
+                this.player1.clickCard(this.envoyP1);
+
+                expect(this.experimentP1.getMilitarySkill()).toBe(2);
+                expect(this.experimentP1.getPoliticalSkill()).toBe(1);
+                expect(this.experimentP2.getMilitarySkill()).toBe(2);
+                expect(this.experimentP2.getPoliticalSkill()).toBe(1);
+
+                expect(this.jealousP1.getMilitarySkill()).toBe(0);
+                expect(this.jealousP1.getPoliticalSkill()).toBe(0);
+                expect(this.jealousP2.getMilitarySkill()).toBe(0);
+                expect(this.jealousP2.getPoliticalSkill()).toBe(0);
+
+                expect(this.envoyP1.getMilitarySkill()).toBe(1);
+                expect(this.envoyP1.getPoliticalSkill()).toBe(0);
+                expect(this.envoyP2.getMilitarySkill()).toBe(1);
+                expect(this.envoyP2.getPoliticalSkill()).toBe(0);
+
+                expect(this.borderlandsP1.getMilitarySkill()).toBe(3);
+                expect(this.borderlandsP1.getPoliticalSkill()).toBe(3);
+                expect(this.borderlandsP2.getMilitarySkill()).toBe(3);
+                expect(this.borderlandsP2.getPoliticalSkill()).toBe(3);
+            });
+
+            it('When Juurou is not in the conflict, it gives skill penalty to shadowlands', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.experimentP1, this.jealousP1, this.envoyP1, this.borderlandsP1],
+                    defenders: [this.experimentP2, this.jealousP2, this.envoyP2, this.borderlandsP2]
+                });
+
+                this.player2.clickCard(this.afflictionP2);
+                this.player2.clickCard(this.envoyP2);
+
+                this.player1.clickCard(this.afflictionP1);
+                this.player1.clickCard(this.envoyP1);
+
+                expect(this.experimentP1.getMilitarySkill()).toBe(2);
+                expect(this.experimentP1.getPoliticalSkill()).toBe(1);
+                expect(this.experimentP2.getMilitarySkill()).toBe(2);
+                expect(this.experimentP2.getPoliticalSkill()).toBe(1);
+
+                expect(this.jealousP1.getMilitarySkill()).toBe(0);
+                expect(this.jealousP1.getPoliticalSkill()).toBe(0);
+                expect(this.jealousP2.getMilitarySkill()).toBe(0);
+                expect(this.jealousP2.getPoliticalSkill()).toBe(0);
+
+                expect(this.envoyP1.getMilitarySkill()).toBe(1);
+                expect(this.envoyP1.getPoliticalSkill()).toBe(0);
+                expect(this.envoyP2.getMilitarySkill()).toBe(1);
+                expect(this.envoyP2.getPoliticalSkill()).toBe(0);
+
+                expect(this.borderlandsP1.getMilitarySkill()).toBe(3);
+                expect(this.borderlandsP1.getPoliticalSkill()).toBe(3);
+                expect(this.borderlandsP2.getMilitarySkill()).toBe(3);
+                expect(this.borderlandsP2.getPoliticalSkill()).toBe(3);
+            });
+        });
+
+        describe('Action taint ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['kuni-juurou', 'kaiu-envoy'],
+                        hand: ['fine-katana', 'finger-of-jade']
+                    },
+                    player2: {
+                        inPlay: ['borderlands-defender'],
+                        hand: ['ornate-fan']
+                    }
+                });
+
+                this.kuniAina = this.player1.findCardByName('kuni-juurou');
+                this.envoy = this.player1.findCardByName('kaiu-envoy');
+                this.katana = this.player1.findCardByName('fine-katana');
+                this.finger = this.player1.findCardByName('finger-of-jade');
+                this.borderlands = this.player2.findCardByName('borderlands-defender');
+                this.fan = this.player2.findCardByName('ornate-fan');
+            });
+
+            it('When Juurou has more cards in hand, cannot be triggered', function () {
+                this.player1.clickCard(this.kuniAina);
+                expect(this.player1).toHavePrompt('Initiate an action');
+            });
+
+            it('When Juurou has the same amount of cards in hand, taint a character', function () {
+                this.player1.clickCard(this.katana);
+                this.player1.clickCard(this.kuniAina);
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.kuniAina);
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.kuniAina);
+                expect(this.player1).toBeAbleToSelect(this.envoy);
+                expect(this.player1).toBeAbleToSelect(this.borderlands);
+
+                this.player1.clickCard(this.borderlands);
+                expect(this.borderlands.isTainted).toBe(true);
+
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Kuni Juurou to identify the source of Crab\'s misfortune… it is Borderlands Defender! Borderlands Defender is tainted.'
+                );
+            });
+
+            it('When Juurou has fewer cards in hand, taint a character', function () {
+                this.player1.clickCard(this.katana);
+                this.player1.clickCard(this.kuniAina);
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.finger);
+                this.player1.clickCard(this.kuniAina);
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.kuniAina);
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.kuniAina);
+                expect(this.player1).toBeAbleToSelect(this.envoy);
+                expect(this.player1).toBeAbleToSelect(this.borderlands);
+
+                this.player1.clickCard(this.borderlands);
+                expect(this.borderlands.isTainted).toBe(true);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Kuni Juurou to identify the source of Crab\'s misfortune… it is Borderlands Defender! Borderlands Defender is tainted.'
+                );
+            });
+        });
+
+        describe('Action taint ability - dynasty', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'dynasty',
+                    player1: {
+                        inPlay: ['kuni-juurou', 'kaiu-envoy']
+                    },
+                    player2: {
+                        inPlay: ['borderlands-defender'],
+                        hand: ['ornate-fan']
+                    }
+                });
+
+                this.kuniAina = this.player1.findCardByName('kuni-juurou');
+                this.envoy = this.player1.findCardByName('kaiu-envoy');
+                this.borderlands = this.player2.findCardByName('borderlands-defender');
+                this.fan = this.player2.findCardByName('ornate-fan');
+            });
+
+            it('When Juurou has fewer cards in hand, do not taint a character', function () {
+                this.player1.clickCard(this.kuniAina);
+                expect(this.player1).toHavePrompt('Play cards from provinces');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crab/OutmaneuveredByForce.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/OutmaneuveredByForce.spec.js
@@ -1,0 +1,140 @@
+describe('Outmaneuvered by Force', function () {
+    integration(function () {
+        describe('Outmaneuvered by Force\'s constant ability', function () {
+            describe('For Player 1 with no conflicts declared', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            inPlay: ['crisis-breaker'],
+                            hand: ['outmaneuvered-by-force']
+                        }
+                    });
+                    this.crisisBreaker =
+                        this.player1.findCardByName('crisis-breaker');
+                    this.outmaneuveredByForce = this.player1.findCardByName(
+                        'outmaneuvered-by-force'
+                    );
+                });
+
+                it('immediately declare conflict', function () {
+                    this.player1.clickCard(this.outmaneuveredByForce);
+                    expect(this.player1).toHavePrompt('Initiate Conflict');
+                });
+            });
+
+            describe('For Player 2 with no conflicts declared', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player2: {
+                            inPlay: ['crisis-breaker'],
+                            hand: ['outmaneuvered-by-force']
+                        }
+                    });
+                    this.crisisBreaker =
+                        this.player2.findCardByName('crisis-breaker');
+                    this.outmaneuveredByForce = this.player2.findCardByName(
+                        'outmaneuvered-by-force'
+                    );
+                });
+
+                it('immediately declare conflict', function () {
+                    this.player1.pass();
+                    this.player2.clickCard(this.outmaneuveredByForce);
+                    expect(this.player2).toHavePrompt('Initiate Conflict');
+                });
+            });
+
+            describe('Depending on high printed military character', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            inPlay: ['matsu-seventh-legion'],
+                            hand: ['outmaneuvered-by-force']
+                        }
+                    });
+                    this.matsuSeventhLegion = this.player1.findCardByName(
+                        'matsu-seventh-legion'
+                    );
+                    this.outmaneuveredByForce = this.player1.findCardByName(
+                        'outmaneuvered-by-force'
+                    );
+                });
+
+                it('immediately declare conflict', function () {
+                    this.player1.clickCard(this.outmaneuveredByForce);
+                    expect(this.player1).toHavePrompt('Initiate Conflict');
+                });
+            });
+
+            describe('With high military skill, but too low printed value', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            inPlay: ['commander-of-the-legions'],
+                            hand: ['fine-katana', 'outmaneuvered-by-force']
+                        }
+                    });
+                    this.commanderOfTheLegions = this.player1.findCardByName(
+                        'commander-of-the-legions'
+                    );
+                    this.fineKatana =
+                        this.player1.findCardByName('fine-katana');
+                    this.outmaneuveredByForce = this.player1.findCardByName(
+                        'outmaneuvered-by-force'
+                    );
+                });
+
+                it('cannot be used', function () {
+                    this.player1.clickCard(this.fineKatana);
+                    this.player1.clickCard(this.commanderOfTheLegions);
+                    this.player2.pass();
+                    this.player1.clickCard(this.outmaneuveredByForce);
+                    expect(this.player1).not.toBeAbleToSelect(
+                        this.outmaneuveredByForce
+                    );
+                });
+            });
+
+            describe('When conflicts were declared', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            inPlay: ['adept-of-the-waves']
+                        },
+                        player2: {
+                            inPlay: ['crisis-breaker'],
+                            hand: ['outmaneuvered-by-force']
+                        }
+                    });
+                    this.adeptOfTheWaves =
+                        this.player1.findCardByName('adept-of-the-waves');
+                    this.crisisBreaker =
+                        this.player2.findCardByName('crisis-breaker');
+                    this.outmaneuveredByForce = this.player2.findCardByName(
+                        'outmaneuvered-by-force'
+                    );
+                });
+
+                it('cannot be used', function () {
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        attackers: [this.adeptOfTheWaves],
+                        defenders: []
+                    });
+                    this.noMoreActions();
+                    this.player1.clickPrompt('Don\'t Resolve');
+
+                    this.player1.pass();
+                    expect(this.player2).not.toBeAbleToSelect(
+                        this.outmaneuveredByForce
+                    );
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crab/ProtectedMerchant.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/ProtectedMerchant.spec.js
@@ -1,0 +1,35 @@
+describe('Protected Merchant', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    dynastyDiscard: ['hidden-moon-dojo', 'karada-district', 'chisei-district'],
+                    inPlay: ['protected-merchant']
+                },
+                player2: {
+                    dynastyDiscard: ['imperial-storehouse']
+                }
+            });
+
+            this.merchant = this.player1.findCardByName('protected-merchant');
+            this.player2.placeCardInProvince('imperial-storehouse', 'province 1');
+        });
+
+        it('gains 1 glory per holding you control', function () {
+            expect(this.merchant.glory).toBe(0);
+
+            this.player1.placeCardInProvince('hidden-moon-dojo', 'province 1');
+            expect(this.merchant.glory).toBe(1);
+
+            this.player1.placeCardInProvince('karada-district', 'province 2');
+            expect(this.merchant.glory).toBe(2);
+        });
+
+        it('has a max of 2 glory gained through effect', function () {
+            this.player1.placeCardInProvince('hidden-moon-dojo', 'province 1');
+            this.player1.placeCardInProvince('karada-district', 'province 2');
+            this.player1.placeCardInProvince('chisei-district', 'province 3');
+            expect(this.merchant.glory).toBe(2);
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crab/ShoreOfTheAshenFlames.spec.js
+++ b/test/server/cards/19.1-AS01/Crab/ShoreOfTheAshenFlames.spec.js
@@ -1,0 +1,150 @@
+describe('Shore of the Ashen Flames', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['aggressive-moto', 'kakita-yoshi'],
+                    hand: [
+                        'a-perfect-cut',
+                        'fine-katana',
+                        'curved-blade',
+                        'invocation-of-ash',
+                        'fiery-madness'
+                    ]
+                },
+                player2: {
+                    inPlay: ['togashi-initiate'],
+                    hand: ['fine-katana'],
+                    provinces: ['shore-of-the-ashen-flames']
+                }
+            });
+
+            this.yoshi = this.player1.findCardByName('kakita-yoshi');
+            this.aggressiveMoto = this.player1.findCardByName('aggressive-moto');
+            this.perfectCut = this.player1.findCardByName('a-perfect-cut');
+            this.fineKatana = this.player1.findCardByName('fine-katana');
+            this.curvedBlade = this.player1.findCardByName('curved-blade');
+            this.invocationOfAsh = this.player1.findCardByName('invocation-of-ash');
+            this.fieryMadness = this.player1.findCardByName('fiery-madness');
+            this.katana2 = this.player2.findCardByName('fine-katana');
+            this.initiate = this.player2.findCardByName('togashi-initiate');
+
+            this.shoreOfTheAshenFlames = this.player2.findCardByName(
+                'shore-of-the-ashen-flames',
+                'province 1'
+            );
+        });
+
+        it('denies attachment bonuses on attackers during resolution but not during the conflict', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.aggressiveMoto],
+                defenders: [this.initiate],
+                province: this.shoreOfTheAshenFlames,
+                type: 'military'
+            });
+
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(3);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(0);
+
+            this.player2.pass();
+            this.player1.clickCard(this.fineKatana);
+            this.player1.clickCard(this.aggressiveMoto);
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(5);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(0);
+
+            this.player2.pass();
+            this.player1.clickCard(this.invocationOfAsh);
+            this.player1.clickCard(this.aggressiveMoto);
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(7);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(2);
+
+            this.player2.pass();
+            this.player1.clickCard(this.curvedBlade);
+            this.player1.clickCard(this.aggressiveMoto);
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(10);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(2);
+
+            this.player2.playAttachment(this.katana2, this.initiate);
+
+            this.noMoreActions();
+            expect(this.getChatLogs(3)).toContain('player1 won a military conflict 3 vs 3');
+        });
+
+        it('allows attachment penalties', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.aggressiveMoto],
+                defenders: [],
+                province: this.shoreOfTheAshenFlames,
+                type: 'military'
+            });
+
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(3);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(0);
+
+            this.player2.pass();
+            this.player1.clickCard(this.fieryMadness);
+            this.player1.clickCard(this.aggressiveMoto);
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(1);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(0);
+
+            this.noMoreActions();
+            expect(this.getChatLogs(3)).toContain('player1 won a military conflict 1 vs 0');
+        });
+
+        it('allows event bonuses', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.aggressiveMoto],
+                defenders: [],
+                province: this.shoreOfTheAshenFlames,
+                type: 'military'
+            });
+
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(3);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(0);
+
+            this.player2.pass();
+            this.player1.clickCard(this.perfectCut);
+            this.player1.clickCard(this.aggressiveMoto);
+            expect(this.aggressiveMoto.getMilitarySkill()).toBe(5);
+            expect(this.aggressiveMoto.getPoliticalSkill()).toBe(0);
+
+            this.noMoreActions();
+            expect(this.getChatLogs(5)).toContain('player1 won a military conflict 5 vs 0');
+        });
+
+        it('testing pol', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.yoshi],
+                defenders: [],
+                province: this.shoreOfTheAshenFlames,
+                type: 'political'
+            });
+
+            expect(this.yoshi.getMilitarySkill()).toBe(2);
+            expect(this.yoshi.getPoliticalSkill()).toBe(6);
+
+            this.player2.pass();
+            this.player1.playAttachment(this.fineKatana, this.yoshi);
+            expect(this.yoshi.getMilitarySkill()).toBe(4);
+            expect(this.yoshi.getPoliticalSkill()).toBe(6);
+
+            this.player2.pass();
+            this.player1.playAttachment(this.invocationOfAsh, this.yoshi);
+            expect(this.yoshi.getMilitarySkill()).toBe(6);
+            expect(this.yoshi.getPoliticalSkill()).toBe(8);
+
+            this.player2.pass();
+            this.player1.playAttachment(this.fieryMadness, this.yoshi);
+            expect(this.yoshi.getMilitarySkill()).toBe(4);
+            expect(this.yoshi.getPoliticalSkill()).toBe(6);
+
+            this.noMoreActions();
+            expect(this.getChatLogs(5)).toContain('player1 won a political conflict 4 vs 0');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/ArrowsFromTheWoods.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/ArrowsFromTheWoods.spec.js
@@ -1,0 +1,94 @@
+describe('Arrows from the Woods', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-diplomat', 'brash-samurai', 'isawa-tadaka']
+                },
+                player2: {
+                    inPlay: ['kakita-yoshi', 'doji-challenger', 'adept-of-shadows', 'cautious-scout', 'daidoji-kageyu'],
+                    hand: ['arrows-from-the-woods']
+                }
+            });
+
+            this.brash = this.player1.findCardByName('brash-samurai');
+            this.diplomat = this.player1.findCardByName('doji-diplomat');
+            this.tadaka = this.player1.findCardByName('isawa-tadaka');
+
+            this.yoshi = this.player2.findCardByName('kakita-yoshi');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.adept = this.player2.findCardByName('adept-of-shadows');
+            this.scout = this.player2.findCardByName('cautious-scout');
+            this.kageyu = this.player2.findCardByName('daidoji-kageyu');
+            this.arrows = this.player2.findCardByName('arrows-from-the-woods');
+        });
+
+        it('gives opponents -2 mil if you control a bushi and a shinobi', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat, this.tadaka],
+                defenders: [this.yoshi, this.adept]
+            });
+            this.player2.clickCard(this.arrows);
+            expect(this.diplomat.getMilitarySkill()).toBe(0);
+            expect(this.diplomat.getPoliticalSkill()).toBe(1);
+            expect(this.brash.getMilitarySkill()).toBe(2);
+            expect(this.brash.getPoliticalSkill()).toBe(1);
+            expect(this.tadaka.getMilitarySkill()).toBe(3);
+            expect(this.tadaka.getPoliticalSkill()).toBe(3);
+            expect(this.yoshi.getMilitarySkill()).toBe(2);
+            expect(this.yoshi.getPoliticalSkill()).toBe(6);
+
+            expect(this.getChatLogs(10)).toContain(
+                'player2 plays Arrows from the Woods to give player1\'s participating characters -2military'
+            );
+        });
+
+        it('gives opponents -2 mil if you control a bushi and a scout', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat, this.tadaka],
+                defenders: [this.yoshi, this.challenger, this.scout]
+            });
+            this.player2.clickCard(this.arrows);
+            expect(this.diplomat.getMilitarySkill()).toBe(0);
+            expect(this.brash.getMilitarySkill()).toBe(2);
+            expect(this.tadaka.getMilitarySkill()).toBe(3);
+            expect(this.yoshi.getMilitarySkill()).toBe(2);
+
+            expect(this.getChatLogs(10)).toContain(
+                'player2 plays Arrows from the Woods to give player1\'s participating characters -2military'
+            );
+        });
+
+        it('gives opponents -1 mil if you only have a bushi', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat, this.brash, this.tadaka],
+                defenders: [this.yoshi, this.challenger]
+            });
+            this.player2.clickCard(this.arrows);
+            expect(this.diplomat.getMilitarySkill()).toBe(0);
+            expect(this.brash.getMilitarySkill()).toBe(1);
+            expect(this.tadaka.getMilitarySkill()).toBe(4);
+            expect(this.yoshi.getMilitarySkill()).toBe(2);
+
+            expect(this.getChatLogs(10)).toContain(
+                'player2 plays Arrows from the Woods to give player1\'s participating characters -1military'
+            );
+        });
+
+        it('cannot be used without a bushi', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat, this.brash, this.tadaka],
+                defenders: [this.kageyu]
+            });
+
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            this.player2.clickCard(this.arrows);
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/DaidojiAhma.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/DaidojiAhma.spec.js
@@ -1,0 +1,176 @@
+describe('Daidoji Ahma', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['togashi-initiate'],
+                    hand: ['i-can-swim']
+                },
+                player2: {
+                    inPlay: ['daidoji-uji', 'daidoji-ahma']
+                }
+            });
+            this.togashiInitiate = this.player1.findCardByName('togashi-initiate');
+            this.daidojiUji = this.player2.findCardByName('daidoji-uji');
+            this.ahma = this.player2.findCardByName('daidoji-ahma');
+            this.swim = this.player1.findCardByName('i-can-swim');
+            this.daidojiUji.dishonor();
+
+            this.player1.player.showBid = 5;
+            this.player2.player.showBid = 1;
+        });
+
+        it('void ring', function() {
+            this.daidojiUji.fate = 1;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.togashiInitiate],
+                defenders: [],
+                ring: 'void'
+            });
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Void Ring');
+            this.player1.clickCard(this.daidojiUji);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.ahma);
+            this.player2.clickCard(this.ahma);
+            expect(this.daidojiUji.fate).toBe(1);
+            expect(this.getChatLogs(5)).toContain('player2 uses Daidōji Ahma to cancel the effects of the Void Ring');
+        });
+
+        it('fire ring - honor', function() {
+            this.daidojiUji.fate = 1;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.togashiInitiate],
+                defenders: [],
+                ring: 'fire'
+            });
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Fire Ring');
+            this.player1.clickCard(this.daidojiUji);
+            this.player1.clickPrompt('Honor Daidoji Uji');
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.ahma);
+            this.player2.clickCard(this.ahma);
+            expect(this.daidojiUji.isHonored).toBe(false);
+            expect(this.getChatLogs(5)).toContain('player2 uses Daidōji Ahma to cancel the effects of the Fire Ring');
+        });
+
+        it('fire ring - dishonor', function() {
+            this.daidojiUji.fate = 1;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.togashiInitiate],
+                defenders: [],
+                ring: 'fire'
+            });
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Fire Ring');
+            this.player1.clickCard(this.daidojiUji);
+            this.player1.clickPrompt('Honor Daidoji Uji');
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.ahma);
+            this.player2.clickCard(this.ahma);
+            expect(this.daidojiUji.isDishonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 uses Daidōji Ahma to cancel the effects of the Fire Ring');
+        });
+
+        it('water ring - bow', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.togashiInitiate],
+                defenders: [],
+                ring: 'water'
+            });
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Water Ring');
+            this.player1.clickCard(this.daidojiUji);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.ahma);
+            this.player2.clickCard(this.ahma);
+            expect(this.daidojiUji.bowed).toBe(false);
+            expect(this.getChatLogs(5)).toContain('player2 uses Daidōji Ahma to cancel the effects of the Water Ring');
+        });
+
+        it('water ring - ready', function() {
+            this.daidojiUji.bow();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.togashiInitiate],
+                defenders: [],
+                ring: 'water'
+            });
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Water Ring');
+            this.player1.clickCard(this.daidojiUji);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.ahma);
+            this.player2.clickCard(this.ahma);
+            expect(this.daidojiUji.bowed).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 uses Daidōji Ahma to cancel the effects of the Water Ring');
+        });
+
+        it('event', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.togashiInitiate],
+                defenders: [this.daidojiUji],
+                ring: 'water'
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.swim);
+            this.player1.clickCard(this.daidojiUji);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.ahma);
+            this.player2.clickCard(this.ahma);
+            expect(this.daidojiUji.location).toBe('play area');
+            expect(this.getChatLogs(5)).toContain('player2 uses Daidōji Ahma to cancel the effects of I Can Swim');
+        });
+
+        it('should not interrupt on a non-dishonored character', function() {
+            this.daidojiUji.fate = 1;
+            this.daidojiUji.honor();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.togashiInitiate],
+                defenders: [],
+                ring: 'void'
+            });
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Void Ring');
+            this.player1.clickCard(this.daidojiUji);
+            expect(this.player2).not.toHavePrompt('Triggered Abilities');
+            expect(this.daidojiUji.fate).toBe(0);
+        });
+    });
+});
+
+describe('Daidoji Ahma - reported dynasty bug', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'dynasty',
+                player1: {
+                    inPlay: ['daidoji-ahma', 'doji-kuwanan'],
+                    dynastyDiscard: ['doji-kuwanan']
+                },
+                player2: {
+                }
+            });
+            this.ahma = this.player1.findCardByName('daidoji-ahma');
+            this.kuwananPlay = this.player1.findCardByName('doji-kuwanan', 'play area');
+            this.kuwananProvince = this.player1.findCardByName('doji-kuwanan', 'dynasty discard pile');
+
+            this.player1.moveCard(this.kuwananProvince, 'province 1');
+            this.kuwananProvince.facedown = false;
+            this.kuwananPlay.dishonor();
+        });
+
+        it('should allow duplicating uniques', function() {
+            this.player1.clickCard(this.kuwananProvince);
+            expect(this.kuwananPlay.fate).toBe(1);
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/DaidojiAmbusher.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/DaidojiAmbusher.spec.js
@@ -1,0 +1,107 @@
+describe('Daidoji Ambusher', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-diplomat', 'shosuro-sadako', 'daidoji-ambusher']
+                },
+                player2: {
+                    inPlay: ['daidoji-uji', 'doji-challenger', 'adept-of-shadows']
+                }
+            });
+
+            this.sadako = this.player1.findCardByName('shosuro-sadako');
+            this.diplomat = this.player1.findCardByName('doji-diplomat');
+            this.uji = this.player2.findCardByName('daidoji-uji');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.ambusher = this.player1.findCardByName('daidoji-ambusher');
+            this.adept = this.player2.findCardByName('adept-of-shadows');
+
+            this.adept.fate = 1;
+        });
+
+        it('should target participating characters', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'military',
+                attackers: [this.diplomat, this.ambusher],
+                defenders: [this.challenger]
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.ambusher);
+            expect(this.player1).toBeAbleToSelect(this.diplomat);
+            expect(this.player1).toBeAbleToSelect(this.challenger);
+            expect(this.player1).not.toBeAbleToSelect(this.sadako);
+            expect(this.player1).not.toBeAbleToSelect(this.uji);
+            expect(this.player1).toBeAbleToSelect(this.ambusher);
+        });
+
+        it('should give someone -2 mil and no kicker if not dishonored', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'military',
+                attackers: [this.diplomat, this.sadako, this.ambusher],
+                defenders: [this.uji, this.challenger, this.adept]
+            });
+            this.player2.pass();
+
+            this.player1.clickCard(this.ambusher);
+            this.player1.clickCard(this.adept);
+            expect(this.adept.getMilitarySkill()).toBe(0);
+            expect(this.adept.fate).toBe(1);
+
+            expect(this.getChatLogs(10)).toContain('player1 uses Daidōji Ambusher to give Adept of Shadows -2military');
+        });
+
+        it('should remove a fate', function () {
+            this.ambusher.dishonor();
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'military',
+                attackers: [this.diplomat, this.sadako, this.ambusher],
+                defenders: [this.uji, this.challenger, this.adept]
+            });
+            this.player2.pass();
+
+            this.player1.clickCard(this.ambusher);
+            this.player1.clickCard(this.adept);
+            expect(this.adept.getMilitarySkill()).toBe(0);
+            expect(this.adept.fate).toBe(0);
+            expect(this.getChatLogs(10)).toContain('player1 uses Daidōji Ambusher to give Adept of Shadows -2military and remove a fate from them');
+        });
+
+        it('should discard', function () {
+            this.ambusher.dishonor();
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'military',
+                attackers: [this.diplomat, this.sadako, this.ambusher],
+                defenders: [this.uji, this.challenger, this.adept]
+            });
+            this.player2.pass();
+
+            this.player1.clickCard(this.ambusher);
+            this.player1.clickCard(this.diplomat);
+            expect(this.diplomat.location).toBe('dynasty discard pile');
+            expect(this.getChatLogs(10)).toContain('player1 uses Daidōji Ambusher to give Doji Diplomat -2military and discard them');
+        });
+
+        it('should not discard if skill isn\'t 0', function () {
+            this.ambusher.dishonor();
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'military',
+                attackers: [this.diplomat, this.sadako, this.ambusher],
+                defenders: [this.uji, this.challenger, this.adept]
+            });
+            this.player2.pass();
+
+            this.player1.clickCard(this.ambusher);
+            this.player1.clickCard(this.uji);
+            expect(this.diplomat.location).toBe('play area');
+            expect(this.getChatLogs(10)).toContain('player1 uses Daidōji Ambusher to give Daidoji Uji -2military');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/DesperateAide.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/DesperateAide.spec.js
@@ -1,0 +1,70 @@
+describe('Desperate Aide', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-diplomat', 'brash-samurai', 'isawa-tadaka']
+                },
+                player2: {
+                    inPlay: ['kakita-yoshi', 'desperate-aide']
+                }
+            });
+
+            this.brash = this.player1.findCardByName('brash-samurai');
+            this.diplomat = this.player1.findCardByName('doji-diplomat');
+            this.tadaka = this.player1.findCardByName('isawa-tadaka');
+
+            this.yoshi = this.player2.findCardByName('kakita-yoshi');
+            this.aide = this.player2.findCardByName('desperate-aide');
+
+            this.player1.player.showBid = 5;
+            this.player2.player.showBid = 5;
+        });
+
+        it('should do nothing without composure', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat, this.brash, this.tadaka],
+                defenders: [this.aide]
+            });
+
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            this.player2.clickCard(this.aide);
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+        });
+
+        it('should draw with composure but not gain honor if not winning conflict', function () {
+            this.player2.player.showBid = 1;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat, this.brash, this.tadaka],
+                defenders: [this.aide]
+            });
+
+            let hand = this.player2.hand.length;
+            let honor = this.player2.honor;
+            this.player2.clickCard(this.aide);
+            expect(this.player2.hand.length).toBe(hand + 1);
+            expect(this.player2.honor).toBe(honor);
+            expect(this.getChatLogs(5)).toContain('player2 uses Desperate Aide to draw 1 card');
+        });
+
+        it('should gain honor if winning', function () {
+            this.player2.player.showBid = 1;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat, this.brash, this.tadaka],
+                defenders: [this.yoshi, this.aide],
+                type: 'political'
+            });
+
+            let hand = this.player2.hand.length;
+            let honor = this.player2.honor;
+            this.player2.clickCard(this.aide);
+            expect(this.player2.hand.length).toBe(hand + 1);
+            expect(this.player2.honor).toBe(honor + 1);
+            expect(this.getChatLogs(5)).toContain('player2 uses Desperate Aide to draw 1 card and gain 1 honor');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/DevelopingMasterpiece.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/DevelopingMasterpiece.spec.js
@@ -1,0 +1,112 @@
+describe('Developing Masterpiece', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'draw',
+                player1: {
+                    inPlay: ['brash-samurai', 'kakita-yoshi', 'master-at-arms', 'togashi-initiate'],
+                    hand: ['developing-masterpiece']
+                },
+                player2: {
+                    inPlay: ['doji-whisperer'],
+                    hand: ['let-go']
+                }
+            });
+
+            this.brash = this.player1.findCardByName('brash-samurai');
+            this.yoshi = this.player1.findCardByName('kakita-yoshi');
+            this.arms = this.player1.findCardByName('master-at-arms');
+            this.initiate = this.player1.findCardByName('togashi-initiate');
+
+            this.whisperer = this.player2.findCardByName('doji-whisperer');
+            this.letGo = this.player2.findCardByName('let-go');
+
+            this.masterpiece = this.player1.findCardByName('developing-masterpiece');
+
+            this.player1.player.promptedActionWindows.draw = true;
+            this.player2.player.promptedActionWindows.draw = true;
+
+            this.player1.player.promptedActionWindows.fate = true;
+            this.player2.player.promptedActionWindows.fate = true;
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+            this.yoshi.honor();
+            this.yoshi.fate = 1;
+        });
+
+        it('should let you attach to a crane or courtier or an artisan', function () {
+            this.player1.clickCard(this.masterpiece);
+            expect(this.player1).toBeAbleToSelect(this.yoshi);
+            expect(this.player1).toBeAbleToSelect(this.arms);
+            expect(this.player1).toBeAbleToSelect(this.brash);
+            expect(this.player1).not.toBeAbleToSelect(this.initiate);
+            expect(this.player1).not.toBeAbleToSelect(this.whisperer);
+            this.player1.clickCard(this.yoshi);
+
+            expect(this.masterpiece.location).toBe('play area');
+            expect(this.masterpiece.parent).toBe(this.yoshi);
+        });
+
+        it('should prevent participating', function () {
+            this.player1.clickCard(this.masterpiece);
+            this.player1.clickCard(this.yoshi);
+
+            this.noMoreActions();
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'military',
+                attackers: [this.yoshi, this.initiate],
+                defenders: []
+            });
+
+            expect(this.game.currentConflict.attackers).toContain(this.initiate);
+            expect(this.game.currentConflict.attackers).not.toContain(this.yoshi);
+        });
+
+        it('should let you gain honor in the fate phase', function () {
+            this.player1.clickCard(this.masterpiece);
+            this.player1.clickCard(this.yoshi);
+            this.noMoreActions();
+
+            expect(this.player1).toHavePrompt('Action Window');
+            this.player1.clickCard(this.masterpiece);
+            expect(this.player1).toHavePrompt('Action Window');
+
+            this.advancePhases('fate');
+
+            this.player1.clickPrompt('Done');
+            this.player2.clickPrompt('Done');
+
+            let honor = this.player1.honor;
+            this.player1.clickCard(this.masterpiece);
+            expect(this.masterpiece.location).toBe('removed from game');
+            expect(this.player1.honor).toBe(honor + 3);
+            expect(this.getChatLogs(5)).toContain('player1 uses Developing Masterpiece, removing Developing Masterpiece from the game to gain 3 honor');
+        });
+
+        it('playable from discard', function () {
+            this.player1.clickCard(this.masterpiece);
+            this.player1.clickCard(this.yoshi);
+
+            expect(this.masterpiece.location).toBe('play area');
+            expect(this.masterpiece.parent).toBe(this.yoshi);
+
+            this.player2.clickCard(this.letGo);
+            this.player2.clickCard(this.masterpiece);
+
+            this.player1.clickCard(this.masterpiece);
+            this.player1.clickCard(this.arms);
+
+            expect(this.masterpiece.location).toBe('play area');
+            expect(this.masterpiece.parent).toBe(this.arms);
+        });
+
+        it('not playable in conflict', function () {
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Action Window');
+            this.player1.clickCard(this.masterpiece);
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/ForestOfRustlingWhispers.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/ForestOfRustlingWhispers.spec.js
@@ -1,0 +1,99 @@
+describe('Forest of Rustling Whispers', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-diplomat', 'shiba-tsukune']
+                },
+                player2: {
+                    inPlay: ['daidoji-uji', 'doji-challenger'],
+                    provinces: ['forest-of-rustling-whispers', 'manicured-garden']
+                }
+            });
+            this.diplomat = this.player1.findCardByName('doji-diplomat');
+            this.tsukune = this.player1.findCardByName('shiba-tsukune');
+            this.uji = this.player2.findCardByName('daidoji-uji');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.forest = this.player2.findCardByName('forest-of-rustling-whispers');
+            this.garden = this.player2.findCardByName('manicured-garden');
+            this.noMoreActions();
+        });
+
+        it('should let you pick a participating character', function () {
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [this.uji],
+                province: this.forest
+            });
+            this.player2.clickCard(this.forest);
+            expect(this.player2).toBeAbleToSelect(this.diplomat);
+            expect(this.player2).not.toBeAbleToSelect(this.tsukune);
+            expect(this.player2).toBeAbleToSelect(this.uji);
+            expect(this.player2).not.toBeAbleToSelect(this.challenger);
+        });
+
+        it('should let you honor or dishonor - honoring', function () {
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [this.uji],
+                province: this.forest
+            });
+            this.player2.clickCard(this.forest);
+            this.player2.clickCard(this.uji);
+            expect(this.player2).toHavePrompt('Select an action:');
+            expect(this.player2).toHavePromptButton('Honor this character');
+            expect(this.player2).toHavePromptButton('Dishonor this character');
+            this.player2.clickPrompt('Honor this character');
+            expect(this.uji.isHonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 uses Forest of Rustling Whispers to honor or dishonor Daidoji Uji');
+            expect(this.getChatLogs(5)).toContain('player2 chooses to honor Daidoji Uji');
+        });
+
+        it('should let you honor or dishonor - dishonoring', function () {
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [this.uji],
+                province: this.forest
+            });
+            this.player2.clickCard(this.forest);
+            this.player2.clickCard(this.uji);
+            expect(this.player2).toHavePrompt('Select an action:');
+            expect(this.player2).toHavePromptButton('Honor this character');
+            expect(this.player2).toHavePromptButton('Dishonor this character');
+            this.player2.clickPrompt('Dishonor this character');
+            expect(this.uji.isDishonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 chooses to dishonor Daidoji Uji');
+        });
+
+        it('should let you honor or dishonor - no choice', function () {
+            this.uji.honor();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [this.uji],
+                province: this.forest
+            });
+            this.player2.clickCard(this.forest);
+            this.player2.clickCard(this.uji);
+            expect(this.player2).toHavePrompt('Select an action:');
+            expect(this.player2).not.toHavePromptButton('Honor this character');
+            expect(this.player2).toHavePromptButton('Dishonor this character');
+            this.player2.clickPrompt('Dishonor this character');
+            expect(this.uji.isHonored).toBe(false);
+            expect(this.uji.isDishonored).toBe(false);
+        });
+
+        it('should not trigger at a different province', function () {
+            this.forest.facedown = true;
+            this.uji.honor();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [this.uji],
+                province: this.garden
+            });
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            this.player2.clickCard(this.forest);
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/NaturesWrath.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/NaturesWrath.spec.js
@@ -1,0 +1,139 @@
+describe('Natures Wrath', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-diplomat', 'shosuro-sadako']
+                },
+                player2: {
+                    inPlay: ['daidoji-uji', 'keeper-initiate'],
+                    hand: ['nature-s-wrath']
+                }
+            });
+
+            this.sadako = this.player1.findCardByName('shosuro-sadako');
+            this.diplomat = this.player1.findCardByName('doji-diplomat');
+            this.uji = this.player2.findCardByName('daidoji-uji');
+            this.keeper = this.player2.findCardByName('keeper-initiate');
+            this.wrath = this.player2.findCardByName('nature-s-wrath');
+        });
+
+        it('auto sends home dishonored characters', function () {
+            this.sadako.dishonor();
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.sadako],
+                defenders: [this.uji]
+            });
+
+            this.player2.clickCard(this.wrath);
+            expect(this.player2).toHavePrompt('Choose a character');
+
+            this.player2.clickCard(this.sadako);
+            expect(this.player1).not.toHavePrompt('Select one');
+            expect(this.sadako.isParticipating()).toBe(false);
+            expect(this.sadako.isDishonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 plays Nature\'s Wrath to send Shosuro Sadako home');
+        });
+
+        it('let opponent choose to go home home', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.sadako],
+                defenders: [this.uji]
+            });
+
+            this.player2.clickCard(this.wrath);
+            expect(this.player2).toHavePrompt('Choose a character');
+
+            this.player2.clickCard(this.sadako);
+            expect(this.player1).toHavePrompt('Select one');
+            expect(this.player1).toHavePromptButton('Dishonor this character');
+            expect(this.player1).toHavePromptButton('Move this character home');
+
+            this.player1.clickPrompt('Move this character home');
+            expect(this.sadako.isParticipating()).toBe(false);
+            expect(this.sadako.isDishonored).toBe(false);
+            expect(this.getChatLogs(5)).toContain('player2 plays Nature\'s Wrath to send Shosuro Sadako home');
+        });
+
+        it('let opponent choose to go dishonor their character', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.sadako],
+                defenders: [this.uji]
+            });
+
+            this.player2.clickCard(this.wrath);
+            expect(this.player2).toHavePrompt('Choose a character');
+
+            this.player2.clickCard(this.sadako);
+            expect(this.player1).toHavePrompt('Select one');
+            expect(this.player1).toHavePromptButton('Dishonor this character');
+            expect(this.player1).toHavePromptButton('Move this character home');
+
+            this.player1.clickPrompt('Dishonor this character');
+            expect(this.sadako.isParticipating()).toBe(true);
+            expect(this.sadako.isDishonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 plays Nature\'s Wrath to dishonor Shosuro Sadako');
+        });
+
+        it('can dishonor participating character to use it again', function () {
+            this.sadako.dishonor();
+            this.uji.honor();
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.sadako, this.diplomat],
+                defenders: [this.uji]
+            });
+
+            this.player2.clickCard(this.wrath);
+            expect(this.player2).toHavePrompt('Choose a character');
+
+            this.player2.clickCard(this.sadako);
+            expect(this.sadako.isParticipating()).toBe(false);
+            expect(this.sadako.isDishonored).toBe(true);
+
+            expect(this.player2).toHavePrompt('Select one');
+            expect(this.player2).toHavePromptButton('Dishonor a participating character to resolve this ability again');
+            expect(this.player2).toHavePromptButton('Done');
+
+            this.player2.clickPrompt('Dishonor a participating character to resolve this ability again');
+            expect(this.player2).toHavePrompt('Choose a character');
+            expect(this.player2).toBeAbleToSelect(this.uji);
+            expect(this.player2).not.toBeAbleToSelect(this.keeper);
+
+            this.player2.clickCard(this.uji);
+            expect(this.uji.isOrdinary()).toBe(true);
+            expect(this.getChatLogs(5)).toContain(
+                'player2 chooses to dishonor Daidoji Uji to resolve Nature\'s Wrath again'
+            );
+
+            expect(this.player2).toHavePrompt('Choose a character');
+
+            this.player2.clickCard(this.diplomat);
+            expect(this.player1).toHavePrompt('Select one');
+            expect(this.player1).toHavePromptButton('Dishonor this character');
+            expect(this.player1).toHavePromptButton('Move this character home');
+
+            this.player1.clickPrompt('Dishonor this character');
+            expect(this.diplomat.isParticipating()).toBe(true);
+            expect(this.diplomat.isDishonored).toBe(true);
+
+            expect(this.player2).toHavePrompt('Select one');
+            expect(this.player2).toHavePromptButton('Dishonor a participating character for no effect');
+            expect(this.player2).toHavePromptButton('Done');
+
+            this.player2.clickPrompt('Dishonor a participating character for no effect');
+            this.player2.clickCard(this.uji);
+
+            expect(this.uji.isDishonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 chooses to dishonor Daidoji Uji for no effect');
+
+            expect(this.player2).not.toHavePrompt('Choose a character');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Crane/StormFromSakkaku.spec.js
+++ b/test/server/cards/19.1-AS01/Crane/StormFromSakkaku.spec.js
@@ -1,0 +1,233 @@
+describe('Storm from Sakkaku', function () {
+    integration(function () {
+        describe('Storm from Sakkaku persistent ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        dynastyDeck: ['akodo-toturi'],
+                        dynastyDiscard: [
+                            'shintao-monastery',
+                            'shintao-monastery',
+                            'shintao-monastery',
+                            'shintao-monastery'
+                        ],
+                        inPlay: ['tattooed-wanderer', 'togashi-mitsu-2'],
+                        hand: ['seeker-of-knowledge', 'fine-katana', 'charge', 'restored-heirloom', 'chasing-the-sun']
+                    },
+                    player2: {
+                        role: 'keeper-of-water',
+                        provinces: ['manicured-garden', 'entrenched-position'],
+                        dynastyDiscard: ['storm-from-sakkaku'],
+                        inPlay: [],
+                        hand: ['display-of-power'],
+                        dynastyDeck: ['keeper-initiate']
+                    }
+                });
+                this.player1.placeCardInProvince(
+                    this.player1.findCardByName('shintao-monastery', 'dynasty discard pile'),
+                    'province 1'
+                );
+                this.player1.placeCardInProvince(
+                    this.player1.findCardByName('shintao-monastery', 'dynasty discard pile'),
+                    'province 2'
+                );
+                this.player1.placeCardInProvince(
+                    this.player1.findCardByName('shintao-monastery', 'dynasty discard pile'),
+                    'province 3'
+                );
+                this.player1.placeCardInProvince(
+                    this.player1.findCardByName('shintao-monastery', 'dynasty discard pile'),
+                    'province 4'
+                );
+
+                this.player2.placeCardInProvince(
+                    this.player2.findCardByName('storm-from-sakkaku', 'dynasty discard pile'),
+                    'province 1'
+                );
+
+                this.mitsu = this.player1.findCardByName('togashi-mitsu-2');
+                this.mitsu.dishonor();
+
+                this.game.checkGameState(true);
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.mitsu],
+                    ring: 'earth',
+                    defenders: [],
+                    province: 'manicured-garden'
+                });
+                this.player2.pass();
+                this.player1.clickCard('seeker-of-knowledge');
+                this.player1.clickPrompt('0');
+                this.player1.clickPrompt('Home');
+                this.player2.pass();
+            });
+
+            describe('When the province is not broken', function () {
+                it('should cancel the effects of the conflict ring', function () {
+                    this.noMoreActions();
+                    expect(this.player1).toHavePrompt('Action Window');
+                    expect(this.getChatLogs(1)).toContain('Storm from Sakkaku cancels the ring effect');
+                });
+
+                it('should cancel conflict ring resolution due to card effects', function () {
+                    this.player1.pass();
+                    this.player2.pass();
+                    this.player2.clickCard('display-of-power');
+                    expect(this.player1).toHavePrompt('Action Window');
+                    expect(this.getChatLogs(1)).toContain('Storm from Sakkaku cancels the ring effect');
+                });
+
+                //Repro: Togashi Mitsu (2)
+                it('should cancel other ring effects resolved by cards', function () {
+                    this.player1.clickCard('togashi-mitsu-2');
+                    this.player1.clickRing('fire');
+                    expect(this.player2).toHavePrompt('Conflict Action Window');
+                    expect(this.getChatLogs(3)).toContain('Storm from Sakkaku cancels the ring effect');
+                });
+
+                it('should take effect before interrupts can trigger', function () {
+                    this.player1.clickCard('togashi-mitsu-2');
+                    this.player1.clickRing('water');
+                    expect(this.player2).toHavePrompt('Conflict Action Window');
+                    expect(this.getChatLogs(3)).toContain('Storm from Sakkaku cancels the ring effect');
+                });
+            });
+
+            describe('when the province is broken', function () {
+                beforeEach(function () {
+                    this.mitsu.honor();
+                    this.player1.clickCard('fine-katana');
+                    this.player1.clickCard('togashi-mitsu-2');
+                    this.player2.pass();
+                    this.player1.pass();
+                });
+
+                describe('when the attacker discards the holding from the province', function () {
+                    it('should not cancel the effects of the conflict ring', function () {
+                        this.player2.pass();
+                        this.player1.clickPrompt('Yes');
+                        expect(this.player1).toHavePrompt('Earth Ring');
+                    });
+
+                    it('should not cancel conflict ring resolution due to card effects', function () {
+                        this.player2.clickCard('display-of-power');
+                        this.player1.clickPrompt('Yes');
+                        expect(this.player2).toHavePrompt('Earth Ring');
+                    });
+                });
+
+                describe('when the attacker does not discard the holding from the province', function () {
+                    it('should cancel the effects of the conflict ring', function () {
+                        this.player2.pass();
+                        this.player1.clickPrompt('No');
+                        expect(this.player1).toHavePrompt('Action Window');
+                        expect(this.getChatLogs(1)).toContain('Storm from Sakkaku cancels the ring effect');
+                    });
+
+                    it('should cancel conflict ring resolution due to card effects', function () {
+                        this.player2.clickCard('display-of-power');
+                        this.player1.clickPrompt('No');
+                        expect(this.player1).toHavePrompt('Action Window');
+                        expect(this.getChatLogs(1)).toContain('Storm from Sakkaku cancels the ring effect');
+                    });
+                });
+            });
+
+            describe('when the conflict is moved elsewhere', function () {
+                beforeEach(function () {
+                    this.player1.clickCard('chasing-the-sun');
+                    this.player1.clickCard(this.player2.findCardByName('entrenched-position'));
+                    this.player2.pass();
+                });
+
+                it('should not cancel the effects of the conflict ring', function () {
+                    this.noMoreActions();
+                    expect(this.player1).toHavePrompt('Earth Ring');
+                });
+
+                it('should not cancel conflict ring resolution due to card effects', function () {
+                    this.player1.pass();
+                    this.player2.clickCard('display-of-power');
+                    expect(this.player2).toHavePrompt('Earth Ring');
+                });
+
+                it('should not cancel other ring effects resolved by cards', function () {
+                    this.player1.clickCard('togashi-mitsu-2');
+                    this.player1.clickRing('fire');
+                    expect(this.player1).toHavePrompt('Fire Ring');
+                });
+            });
+        });
+
+        describe('Storm from Sakkaku movement ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        dynastyDiscard: [
+                            'storm-from-sakkaku',
+                            'imperial-storehouse',
+                            'a-season-of-war',
+                            'dispatch-to-nowhere',
+                            'aranat'
+                        ],
+                        provinces: ['manicured-garden', 'endless-plains', 'fertile-fields', 'magistrate-station']
+                    }
+                });
+
+                this.stormFromSakkaku = this.player1.findCardByName('storm-from-sakkaku', 'dynasty discard pile');
+
+                this.player1.placeCardInProvince(this.stormFromSakkaku, 'province 1');
+                this.storehouse = this.player1.findCardByName('imperial-storehouse', 'dynasty discard pile');
+                this.player1.placeCardInProvince(this.storehouse, 'province 2');
+                this.season = this.player1.findCardByName('a-season-of-war', 'dynasty discard pile');
+                this.player1.placeCardInProvince(this.season, 'province 3');
+                this.aranat = this.player1.findCardByName('aranat', 'dynasty discard pile');
+                this.player1.placeCardInProvince(this.aranat, 'province 4');
+
+                this.p1 = this.player1.findCardByName('manicured-garden');
+                this.p2 = this.player1.findCardByName('endless-plains');
+                this.p3 = this.player1.findCardByName('fertile-fields');
+                this.p4 = this.player1.findCardByName('magistrate-station');
+                this.sh = this.player1.findCardByName('shameful-display', 'stronghold province');
+            });
+
+            it('moves to another non-sh province', function () {
+                expect(this.stormFromSakkaku.location).toBe('province 1');
+
+                this.player1.clickCard(this.stormFromSakkaku);
+                expect(this.player1).toHavePrompt('Choose a province');
+                expect(this.player1).not.toBeAbleToSelect(this.sh);
+                expect(this.player1).not.toBeAbleToSelect(this.p1);
+                expect(this.player1).toBeAbleToSelect(this.p2);
+                expect(this.player1).toBeAbleToSelect(this.p3);
+                expect(this.player1).toBeAbleToSelect(this.p4);
+                this.player1.clickCard(this.p4);
+                expect(this.stormFromSakkaku.location).toBe('province 4');
+                expect(this.aranat.location).toBe('province 4');
+                expect(this.getChatLogs(5)).toContain('The Storm from Sakkaku calms down');
+            });
+
+            it('moves to another province, and discard other faceup holdings in there', function () {
+                expect(this.stormFromSakkaku.location).toBe('province 1');
+
+                this.player1.clickCard(this.stormFromSakkaku);
+                expect(this.player1).toHavePrompt('Choose a province');
+                expect(this.player1).not.toBeAbleToSelect(this.sh);
+                expect(this.player1).not.toBeAbleToSelect(this.p1);
+                expect(this.player1).toBeAbleToSelect(this.p2);
+                expect(this.player1).toBeAbleToSelect(this.p3);
+                expect(this.player1).toBeAbleToSelect(this.p4);
+                this.player1.clickCard(this.p2);
+                expect(this.stormFromSakkaku.location).toBe('province 2');
+                expect(this.storehouse.location).toBe('dynasty discard pile');
+                expect(this.getChatLogs(5)).toContain(
+                    'The Storm from Sakkaku is angry and discards the holdings that they find in the province'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/BambooTattoo.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/BambooTattoo.spec.js
@@ -1,0 +1,190 @@
+describe('Bamboo Tattoo', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-kuwanan']
+                },
+                player2: {
+                    inPlay: ['impulsive-novice', 'doomed-shugenja', 'togashi-mitsu'],
+                    provinces: ['courteous-greeting'],
+                    hand: ['bamboo-tattoo', 'high-kick', 'being-and-becoming']
+                }
+            });
+
+            this.kuwanan = this.player1.findCardByName('doji-kuwanan');
+            this.doomed = this.player2.findCardByName('doomed-shugenja');
+            this.novice = this.player2.findCardByName('impulsive-novice');
+            this.mitsu = this.player2.findCardByName('togashi-mitsu');
+
+            this.bamboo = this.player2.findCardByName('bamboo-tattoo');
+            this.kick = this.player2.findCardByName('high-kick');
+            this.beingAndBecoming = this.player2.findCardByName('being-and-becoming');
+            this.greeting = this.player2.findCardByName('courteous-greeting');
+
+            this.game.rings.fire.fate = 2;
+        });
+
+        it('should only be playable on monks and cost 1 when played on someone expensive', function () {
+            let fate = this.player2.fate;
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+
+            expect(this.player2).toBeAbleToSelect(this.novice);
+            expect(this.player2).not.toBeAbleToSelect(this.doomed);
+            expect(this.player2).toBeAbleToSelect(this.mitsu);
+            this.player2.clickCard(this.mitsu);
+
+            expect(this.player2.fate).toBe(fate - 1);
+        });
+
+        it('should only be playable on monks and cost 0 when played on someone cheap', function () {
+            let fate = this.player2.fate;
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+
+            expect(this.player2).toBeAbleToSelect(this.novice);
+            expect(this.player2).not.toBeAbleToSelect(this.doomed);
+            expect(this.player2).toBeAbleToSelect(this.mitsu);
+            this.player2.clickCard(this.novice);
+
+            expect(this.player2.fate).toBe(fate);
+        });
+
+        it('should add tattooed trait', function () {
+            this.player1.pass();
+            expect(this.novice.hasTrait('tattooed')).toBe(false);
+            this.player2.clickCard(this.bamboo);
+            this.player2.clickCard(this.novice);
+            expect(this.novice.hasTrait('tattooed')).toBe(true);
+        });
+
+        it('should prompt you to ready when you bow attached character for a cost', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+            this.player2.clickCard(this.novice);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.kuwanan],
+                defenders: [this.novice]
+            });
+            this.player2.clickCard(this.kick);
+            this.player2.clickCard(this.kuwanan);
+            this.player2.clickCard(this.novice);
+
+            expect(this.novice.bowed).toBe(true);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.bamboo);
+            this.player2.clickCard(this.bamboo);
+            expect(this.novice.bowed).toBe(false);
+            expect(this.novice.isDishonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 uses Bamboo Tattoo to ready and dishonor Impulsive Novice');
+        });
+
+        it('should prompt you to ready when you bow attached character for an effect', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+            this.player2.clickCard(this.novice);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                province: this.greeting,
+                attackers: [this.kuwanan],
+                defenders: [this.novice]
+            });
+            this.player2.clickCard(this.greeting);
+            this.player2.clickCard(this.novice);
+            this.player2.clickCard(this.kuwanan);
+
+            expect(this.novice.bowed).toBe(true);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.bamboo);
+            this.player2.clickCard(this.bamboo);
+            expect(this.novice.bowed).toBe(false);
+            expect(this.novice.isDishonored).toBe(true);
+            expect(this.getChatLogs(5)).toContain('player2 uses Bamboo Tattoo to ready and dishonor Impulsive Novice');
+        });
+
+        it('should prompt you to ready when attached character is bowed by opponent', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+            this.player2.clickCard(this.novice);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.kuwanan],
+                defenders: [this.novice]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.kuwanan);
+            this.player1.clickCard(this.novice);
+
+            expect(this.novice.bowed).toBe(true);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.bamboo);
+            this.player2.clickCard(this.bamboo);
+            expect(this.novice.bowed).toBe(false);
+            expect(this.novice.isDishonored).toBe(false);
+
+            expect(this.getChatLogs(5)).toContain('player2 uses Bamboo Tattoo to ready Impulsive Novice');
+        });
+
+        it('should also prompt you to ready outside conflicts', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+            this.player2.clickCard(this.novice);
+
+            this.player1.pass();
+            this.player2.clickCard(this.beingAndBecoming);
+            this.player2.clickCard(this.novice);
+
+            this.player1.pass();
+            this.player2.clickCard(this.beingAndBecoming);
+            this.player2.clickRing('fire');
+
+            expect(this.novice.bowed).toBe(true);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.bamboo);
+
+            this.player2.clickCard(this.bamboo);
+            expect(this.novice.bowed).toBe(false);
+            expect(this.getChatLogs(5)).toContain('player2 uses Bamboo Tattoo to ready and dishonor Impulsive Novice');
+        });
+
+        it('should not prompt you to ready when attached character is bowed by framework', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+            this.player2.clickCard(this.novice);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.kuwanan],
+                defenders: [this.novice, this.mitsu]
+            });
+            this.noMoreActions();
+
+            expect(this.novice.bowed).toBe(true);
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+
+        it('should not prompt you to ready when attached character is bowed by ring', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.bamboo);
+            this.player2.clickCard(this.novice);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.kuwanan],
+                defenders: [this.mitsu],
+                ring: 'water'
+            });
+            this.noMoreActions();
+            this.player1.clickCard(this.novice);
+
+            expect(this.novice.bowed).toBe(true);
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/CliffsOftheSeaDragon.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/CliffsOftheSeaDragon.spec.js
@@ -1,0 +1,146 @@
+describe('Cliffs of the Sea Dragon', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['solemn-scholar', 'shiba-tsukune']
+                },
+                player2: {
+                    inPlay: ['daidoji-uji', 'doji-challenger', 'eager-scout'],
+                    provinces: ['cliffs-of-the-sea-dragon', 'manicured-garden']
+                }
+            });
+            this.solemnScholar = this.player1.findCardByName('solemn-scholar');
+            this.tsukune = this.player1.findCardByName('shiba-tsukune');
+            this.uji = this.player2.findCardByName('daidoji-uji');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.eagerScout = this.player2.findCardByName('eager-scout');
+            this.cliffs = this.player2.findCardByName('cliffs-of-the-sea-dragon');
+            this.garden = this.player2.findCardByName('manicured-garden');
+        });
+
+        it('should stop opponent from taking fate from rings', function () {
+            this.game.rings.air.fate = 5;
+            let fate = this.player1.fate;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [this.uji],
+                province: this.cliffs,
+                ring: 'air'
+            });
+            expect(this.player1.fate).toBe(fate);
+        });
+
+        it('if you lost a conflict this round, should not stop opponent from taking fate from rings', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [],
+                province: this.cliffs,
+                ring: 'void'
+            });
+            this.noMoreActions();
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.eagerScout],
+                defenders: [],
+                ring: 'earth'
+            });
+            this.noMoreActions();
+
+            this.game.rings.air.fate = 5;
+            let fate = this.player1.fate;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.tsukune],
+                defenders: [],
+                province: this.cliffs,
+                ring: 'air'
+            });
+
+            expect(this.player1.fate).toBe(fate + 5);
+        });
+
+        it('if the opponent passed a conflict this round, should not stop opponent from taking fate from rings', function () {
+            this.noMoreActions();
+            this.player1.passConflict();
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.eagerScout],
+                defenders: [],
+                ring: 'earth'
+            });
+            this.noMoreActions();
+
+            this.game.rings.air.fate = 5;
+            let fate = this.player1.fate;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.tsukune],
+                defenders: [],
+                province: this.cliffs,
+                ring: 'air'
+            });
+
+            expect(this.player1.fate).toBe(fate + 5);
+        });
+
+        it('if you passed a conflict this round, should not stop opponent from taking fate from rings', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [],
+                province: this.cliffs,
+                ring: 'void'
+            });
+            this.noMoreActions();
+
+            this.noMoreActions();
+            this.player2.passConflict();
+
+            this.game.rings.air.fate = 5;
+            let fate = this.player1.fate;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.tsukune],
+                defenders: [],
+                province: this.cliffs,
+                ring: 'air'
+            });
+
+            expect(this.player1.fate).toBe(fate + 5);
+        });
+
+        it('if broken, should not stop opponent from taking fate from rings', function () {
+            this.game.rings.air.fate = 5;
+            this.cliffs.isBroken = true;
+            let fate = this.player1.fate;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [this.uji],
+                province: this.garden,
+                ring: 'air'
+            });
+            expect(this.player1.fate).toBe(fate + 5);
+        });
+
+        it('should not stop you from taking fate from rings', function () {
+            this.game.rings.air.fate = 5;
+            let fate = this.player2.fate;
+            this.noMoreActions();
+            this.player1.passConflict();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.uji],
+                defenders: [this.solemnScholar],
+                ring: 'air'
+            });
+            expect(this.player2.fate).toBe(fate + 5);
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/KitsukiMasanori.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/KitsukiMasanori.spec.js
@@ -1,0 +1,249 @@
+describe('Kitsuki Masanori', function () {
+    integration(function () {
+        describe('anti-covert', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['iuchi-shahai']
+                    },
+                    player2: {
+                        inPlay: ['kitsuki-masanori', 'doji-whisperer', 'tengu-sensei', 'doji-challenger'],
+                        provinces: ['manicured-garden']
+                    }
+                });
+                this.shahai = this.player1.findCardByName('iuchi-shahai');
+
+                this.masanori = this.player2.findCardByName('kitsuki-masanori');
+                this.whisperer = this.player2.findCardByName('doji-whisperer');
+                this.tengu = this.player2.findCardByName('tengu-sensei');
+                this.challenger = this.player2.findCardByName('doji-challenger');
+                this.garden = this.player2.findCardByName('manicured-garden');
+            });
+
+            it('should not allow being chosen by covert', function () {
+                this.noMoreActions();
+                this.player1.clickRing('air');
+                this.player1.clickCard(this.garden);
+                this.player1.clickCard(this.shahai);
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player1).toHavePrompt('Choose covert target for Iuchi Shahai');
+                expect(this.player1).not.toBeAbleToSelect(this.masanori);
+                expect(this.player1).toBeAbleToSelect(this.whisperer);
+                expect(this.player1).not.toBeAbleToSelect(this.tengu);
+                expect(this.player1).toBeAbleToSelect(this.challenger);
+            });
+        });
+
+        describe('When played reaction', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['mirumoto-raitsugu'],
+                        dynastyDiscard: ['kitsuki-masanori'],
+                        conflictDiscard: [
+                            'a-new-name',
+                            'high-kick',
+                            'duelist-training',
+                            'writ-of-sanctification',
+                            'shiba-s-oath',
+                            'justicar-s-approach'
+                        ],
+                        hand: ['hidden-lineage', 'true-strike-kenjutsu', 'forebearer-s-echoes']
+                    },
+                    player2: {
+                        inPlay: ['iuchi-rimei'],
+                        hand: ['let-go', 'fine-katana']
+                    }
+                });
+
+                this.masanori = this.player1.findCardByName('kitsuki-masanori');
+                this.raitsugu = this.player1.findCardByName('mirumoto-raitsugu');
+                this.echoes = this.player1.findCardByName('forebearer-s-echoes');
+                this.trueStrike = this.player1.findCardByName('true-strike-kenjutsu');
+                this.lineage = this.player1.findCardByName('hidden-lineage');
+
+                this.ann = this.player1.findCardByName('a-new-name'); // not a technique or title
+                this.highKick = this.player1.findCardByName('high-kick'); // technnique, but not an attachment
+                this.duelistTraining = this.player1.findCardByName('duelist-training'); // technique
+                this.writ = this.player1.findCardByName('writ-of-sanctification'); // title - cannot equip
+                this.oath = this.player1.findCardByName('shiba-s-oath'); // title - can equip
+                this.justicarsApproach = this.player1.findCardByName('justicar-s-approach'); // technique in discard - can equip
+
+                this.player1.moveCard(this.ann, 'conflict deck');
+                this.player1.moveCard(this.highKick, 'conflict deck');
+                this.player1.moveCard(this.duelistTraining, 'conflict deck');
+                this.player1.moveCard(this.writ, 'conflict deck');
+                this.player1.moveCard(this.oath, 'conflict deck');
+
+                this.katana = this.player2.findCardByName('fine-katana');
+                this.rimei = this.player2.findCardByName('iuchi-rimei');
+                this.letGo = this.player2.findCardByName('let-go');
+            });
+
+            it('should react to entering play', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.raitsugu],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.echoes);
+                this.player1.clickCard(this.masanori);
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.masanori);
+            });
+
+            it('searches deck for a title or technique and equips it', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.raitsugu],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.echoes);
+                this.player1.clickCard(this.masanori);
+                this.player1.clickCard(this.masanori);
+                expect(this.player1).toHavePrompt('Select where to search');
+                expect(this.player1).toHavePromptButton('Search discard pile');
+                expect(this.player1).toHavePromptButton('Search conflict deck');
+
+                this.player1.clickPrompt('Search conflict deck');
+                expect(this.player1).toHavePrompt('Select an attachment');
+                expect(this.player1).toHavePromptButton(this.oath.name);
+                expect(this.player1).toHavePromptButton(this.duelistTraining.name);
+                expect(this.player1).toHavePromptButton('Take nothing');
+
+                this.player1.clickPrompt(this.duelistTraining.name);
+
+                expect(this.duelistTraining.parent).toBe(this.masanori);
+                expect(this.duelistTraining.location).toBe('play area');
+
+                expect(this.getChatLogs(8)).toContain(
+                    'player1 uses Kitsuki Masanori to search for a Technique or Title'
+                );
+                expect(this.getChatLogs(8)).toContain('player1 searches their conflict deck');
+                expect(this.getChatLogs(8)).toContain(
+                    'player1 takes Duelist Training and attaches it to Kitsuki Masanori'
+                );
+                expect(this.getChatLogs(8)).toContain('player1 is shuffling their conflict deck');
+            });
+
+            it('searches discard pile for a title or technique and equips it', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.raitsugu],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.echoes);
+                this.player1.clickCard(this.masanori);
+                this.player1.clickCard(this.masanori);
+                expect(this.player1).toHavePrompt('Select where to search');
+                expect(this.player1).toHavePromptButton('Search discard pile');
+                expect(this.player1).toHavePromptButton('Search conflict deck');
+
+                this.player1.clickPrompt('Search discard pile');
+                expect(this.player1).toHavePrompt('Select an attachment');
+                expect(this.player1).toHavePromptButton(this.justicarsApproach.name);
+
+                this.player1.clickPrompt(this.justicarsApproach.name);
+                expect(this.justicarsApproach.parent).toBe(this.masanori);
+                expect(this.justicarsApproach.location).toBe('play area');
+
+                expect(this.getChatLogs(8)).toContain(
+                    'player1 uses Kitsuki Masanori to search for a Technique or Title'
+                );
+                expect(this.getChatLogs(8)).toContain('player1 searches their discard pile');
+                expect(this.getChatLogs(8)).toContain(
+                    'player1 takes Justicar\'s Approach and attaches it to Kitsuki Masanori'
+                );
+                expect(this.getChatLogs(8)).not.toContain('player1 is shuffling their conflict deck');
+            });
+
+            it('attachment from deck should be unable to be targeted while its on the character, but others should be fine', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.raitsugu],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.echoes);
+                this.player1.clickCard(this.masanori);
+                this.player1.clickCard(this.masanori);
+                this.player1.clickPrompt('Search conflict deck');
+                this.player1.clickPrompt('Duelist Training');
+
+                this.player2.playAttachment(this.katana, this.masanori);
+                this.player1.playAttachment(this.trueStrike, this.masanori);
+
+                this.player2.clickCard(this.letGo);
+                expect(this.player2).toBeAbleToSelect(this.katana);
+                expect(this.player2).toBeAbleToSelect(this.trueStrike);
+                expect(this.player2).not.toBeAbleToSelect(this.duelistTraining);
+                this.player2.clickPrompt('Cancel');
+
+                this.player2.clickCard(this.rimei);
+                expect(this.player2).not.toBeAbleToSelect(this.katana);
+                expect(this.player2).toBeAbleToSelect(this.trueStrike);
+                expect(this.player2).not.toBeAbleToSelect(this.duelistTraining);
+            });
+
+            it('attachment from discard should be unable to be targeted while its on the character, but others should be fine', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.raitsugu],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.echoes);
+                this.player1.clickCard(this.masanori);
+
+                this.player1.clickCard(this.masanori);
+                this.player1.clickPrompt('Search discard pile');
+                this.player1.clickPrompt(this.justicarsApproach.name);
+
+                this.player2.playAttachment(this.katana, this.masanori);
+                this.player1.playAttachment(this.trueStrike, this.masanori);
+
+                this.player2.clickCard(this.letGo);
+                expect(this.player2).toBeAbleToSelect(this.katana);
+                expect(this.player2).toBeAbleToSelect(this.trueStrike);
+                expect(this.player2).not.toBeAbleToSelect(this.justicarsApproach);
+                this.player2.clickPrompt('Cancel');
+
+                this.player2.clickCard(this.rimei);
+                expect(this.player2).not.toBeAbleToSelect(this.katana);
+                expect(this.player2).toBeAbleToSelect(this.trueStrike);
+                expect(this.player2).not.toBeAbleToSelect(this.justicarsApproach);
+            });
+
+            it('attachment should be able to be targeted while its on a different character', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.raitsugu],
+                    defenders: []
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.echoes);
+                this.player1.clickCard(this.masanori);
+                this.player1.clickCard(this.masanori);
+                this.player1.clickPrompt('Search conflict deck');
+                this.player1.clickPrompt('Duelist Training');
+
+                this.player2.playAttachment(this.katana, this.masanori);
+                this.player1.playAttachment(this.trueStrike, this.masanori);
+                this.player2.pass();
+                this.player1.clickCard(this.lineage);
+                this.player1.clickCard(this.duelistTraining);
+                this.player1.clickCard(this.raitsugu);
+
+                this.player2.clickCard(this.letGo);
+                expect(this.player2).toBeAbleToSelect(this.katana);
+                expect(this.player2).toBeAbleToSelect(this.trueStrike);
+                expect(this.player2).toBeAbleToSelect(this.duelistTraining);
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/KitsukiSeiji.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/KitsukiSeiji.spec.js
@@ -1,0 +1,191 @@
+describe('Kitsuki Seiji', function () {
+    integration(function () {
+        describe('Static ability for variable skill', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['kitsuki-seiji'],
+                        hand: ['game-of-sadane']
+                    },
+                    player2: {
+                        inPlay: ['shiba-tsukune']
+                    }
+                });
+                this.seiji = this.player1.findCardByName('kitsuki-seiji');
+                this.tsukune = this.player2.findCardByName('shiba-tsukune');
+                this.gameOfSadane = this.player1.findCardByName('game-of-sadane');
+            });
+
+            describe('When the bid is odd', function () {
+                beforeEach(function () {
+                    this.player1.player.showBid = 1;
+                    this.noMoreActions();
+                });
+
+                it('gets +2/-2', function () {
+                    expect(this.seiji.militarySkill).toBe(5);
+                    expect(this.seiji.politicalSkill).toBe(1);
+                });
+            });
+
+            describe('When the bid is even', function () {
+                beforeEach(function () {
+                    this.player1.player.showBid = 2;
+                    this.noMoreActions();
+                });
+
+                it('gets -2/+2', function () {
+                    expect(this.seiji.militarySkill).toBe(1);
+                    expect(this.seiji.politicalSkill).toBe(5);
+                });
+            });
+
+            describe('Affects duels', function () {
+                beforeEach(function () {
+                    this.player1.player.showBid = 1;
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        ring: 'void',
+                        attackers: [this.seiji],
+                        defenders: [this.tsukune]
+                    });
+                    this.player2.pass();
+                });
+
+                it('the skill modifiers affect duels', function () {
+                    expect(this.seiji.militarySkill).toBe(5);
+                    expect(this.seiji.politicalSkill).toBe(1);
+
+                    this.player1.clickCard(this.gameOfSadane);
+                    this.player1.clickCard(this.seiji);
+                    this.player1.clickCard(this.tsukune);
+                    this.player1.clickPrompt('2');
+                    this.player2.clickPrompt('2');
+
+                    expect(this.seiji.isHonored).toBe(true);
+                    expect(this.tsukune.isDishonored).toBe(true);
+                });
+            });
+        });
+
+        describe('Interrupt ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['kitsuki-seiji', 'tranquil-philosopher'],
+                        hand: ['elemental-inversion']
+                    },
+                    player2: {
+                        hand: ['written-in-the-stars']
+                    }
+                });
+                this.seiji = this.player1.findCardByName('kitsuki-seiji');
+                this.tranquil = this.player1.findCardByName('tranquil-philosopher');
+                this.elementalInversion = this.player1.findCardByName('elemental-inversion');
+
+                this.writtenInTheStars = this.player2.findCardByName('written-in-the-stars');
+            });
+
+            it('gains fate when water ring gets fate during Fate phase', function () {
+                this.seiji.fate = 1;
+
+                this.flow.finishConflictPhase();
+
+                this.player1.clickPrompt('Done'); // removing fate from characters
+                expect(this.seiji.fate).toBe(0);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.seiji);
+                this.player1.clickCard(this.seiji);
+                expect(this.seiji.fate).toBe(1);
+                expect(this.game.rings.water.fate).toBe(0);
+                expect(this.game.rings.air.fate).toBe(1);
+                expect(this.game.rings.earth.fate).toBe(1);
+                expect(this.game.rings.fire.fate).toBe(1);
+                expect(this.game.rings.void.fate).toBe(1);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Kitsuki Seiji to put the fate that would go on the water ring on Kitsuki Seiji instead'
+                );
+            });
+
+            it('gains fate when water ring gets fate added due to effects', function () {
+                this.seiji.fate = 0;
+                expect(this.seiji.fate).toBe(0);
+
+                this.player1.pass();
+
+                this.player2.clickCard(this.writtenInTheStars);
+                this.player2.clickPrompt('Place one fate on each unclaimed ring with no fate');
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.seiji);
+                this.player1.clickCard(this.seiji);
+                expect(this.seiji.fate).toBe(1);
+                expect(this.game.rings.water.fate).toBe(0);
+                expect(this.game.rings.air.fate).toBe(1);
+                expect(this.game.rings.earth.fate).toBe(1);
+                expect(this.game.rings.fire.fate).toBe(1);
+                expect(this.game.rings.void.fate).toBe(1);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Kitsuki Seiji to put the fate that would go on the water ring on Kitsuki Seiji instead'
+                );
+            });
+
+            it('gains fate when fate is moved to the water ring', function () {
+                this.seiji.fate = 0;
+                this.game.rings.earth.fate = 2;
+                expect(this.seiji.fate).toBe(0);
+
+                this.player1.clickCard(this.tranquil);
+                this.player1.clickRing('earth');
+                this.player1.clickRing('water');
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.seiji);
+                this.player1.clickCard(this.seiji);
+                expect(this.seiji.fate).toBe(1);
+                expect(this.game.rings.water.fate).toBe(0);
+                expect(this.game.rings.earth.fate).toBe(1);
+                expect(this.game.rings.air.fate).toBe(0);
+                expect(this.game.rings.fire.fate).toBe(0);
+                expect(this.game.rings.void.fate).toBe(0);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Kitsuki Seiji to put the fate that would go on the water ring on Kitsuki Seiji instead'
+                );
+            });
+
+            it('gains all the fate when multiple fate is moved to the water ring', function () {
+                this.seiji.fate = 0;
+                this.game.rings.earth.fate = 2;
+                expect(this.seiji.fate).toBe(0);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    ring: 'water',
+                    attackers: [this.seiji],
+                    defenders: []
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.elementalInversion);
+                this.player1.clickRing('earth');
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.seiji);
+                this.player1.clickCard(this.seiji);
+                expect(this.seiji.fate).toBe(2);
+                expect(this.game.rings.water.fate).toBe(0);
+                expect(this.game.rings.earth.fate).toBe(0);
+                expect(this.game.rings.air.fate).toBe(0);
+                expect(this.game.rings.fire.fate).toBe(0);
+                expect(this.game.rings.void.fate).toBe(0);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Kitsuki Seiji to put the fate that would go on the water ring on Kitsuki Seiji instead'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/MasterOfTheBlade.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/MasterOfTheBlade.spec.js
@@ -1,0 +1,223 @@
+/* The card is not going forward for now, but this is a lot of code to lose */
+/* eslint-disable jasmine/no-disabled-tests */
+xdescribe('Master of the Blade', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['master-of-the-blade', 'mirumoto-raitsugu'],
+                    hand: ['fine-katana', 'dragon-s-fang', 'dragon-s-claw', 'a-new-name', 'inscribed-tanto']
+                },
+                player2: {
+                    inPlay: ['doji-challenger', 'doji-kuwanan'],
+                    hand:['mirumoto-s-fury']
+                }
+            });
+
+            this.masterOfTheBlade = this.player1.findCardByName('master-of-the-blade');
+            this.raitsugu = this.player1.findCardByName('mirumoto-raitsugu');
+
+            this.dragonsClaw = this.player1.findCardByName('dragon-s-claw');
+            this.dragonsFang = this.player1.findCardByName('dragon-s-fang');
+            this.fineKatana = this.player1.findCardByName('fine-katana');
+            this.tanto = this.player1.findCardByName('inscribed-tanto');
+            this.ann = this.player1.findCardByName('a-new-name');
+
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.kuwanan = this.player2.findCardByName('doji-kuwanan');
+            this.craneMirumotosFury = this.player2.findCardByName('mirumoto-s-fury');
+
+            this.kuwanan.honor();
+
+            this.player1.playAttachment(this.tanto, this.masterOfTheBlade);
+            this.player2.pass();
+            this.player1.playAttachment(this.dragonsFang, this.masterOfTheBlade);
+            this.player2.pass();
+            this.player1.playAttachment(this.dragonsClaw, this.masterOfTheBlade);
+            this.player2.pass();
+            this.player1.playAttachment(this.ann, this.masterOfTheBlade);
+            this.player2.pass();
+            this.player1.playAttachment(this.fineKatana, this.raitsugu);
+        });
+
+        it('should prompt you to bow an attached weapon', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.challenger);
+            expect(this.player1).toHavePrompt('Select card to bow');
+            expect(this.player1).not.toBeAbleToSelect(this.fineKatana);
+            expect(this.player1).toBeAbleToSelect(this.dragonsFang);
+            expect(this.player1).toBeAbleToSelect(this.dragonsClaw);
+            expect(this.player1).toBeAbleToSelect(this.tanto);
+            expect(this.player1).not.toBeAbleToSelect(this.ann);
+        });
+
+        it('if you win the duel should prompt you to decide if you want to sacrifice a weapon', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.challenger);
+            this.player1.clickCard(this.tanto);
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+
+            expect(this.player1).toHavePromptButton('Sacrifice a weapon to discard loser');
+            expect(this.player1).toHavePromptButton('Bow loser');
+            expect(this.getChatLogs(10)).toContain('player1 uses Master of the Blade, bowing Inscribed Tantō to initiate a military duel : Master of the Blade vs. Doji Challenger');
+            expect(this.getChatLogs(10)).toContain('Duel Effect: bow or discard Doji Challenger');
+        });
+
+        it('sacrificing a weapon should discard', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.challenger);
+            this.player1.clickCard(this.tanto);
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+
+            this.player1.clickPrompt('Sacrifice a weapon to discard loser');
+
+            expect(this.player1).toHavePrompt('Choose a card');
+            expect(this.player1).not.toBeAbleToSelect(this.fineKatana);
+            expect(this.player1).toBeAbleToSelect(this.dragonsFang);
+            expect(this.player1).toBeAbleToSelect(this.dragonsClaw);
+            expect(this.player1).not.toBeAbleToSelect(this.tanto);
+            expect(this.player1).not.toBeAbleToSelect(this.ann);
+
+            this.player1.clickCard(this.dragonsClaw);
+            expect(this.challenger.location).toBe('dynasty discard pile');
+            expect(this.dragonsClaw.location).toBe('conflict discard pile');
+
+            expect(this.getChatLogs(10)).toContain('player1 chooses to sacrifice a weapon to discard Doji Challenger');
+            expect(this.getChatLogs(10)).toContain('player1 sacrifices Dragon\'s Claw');
+        });
+
+        it('not sacrificing a weapon should bow', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.challenger);
+            this.player1.clickCard(this.tanto);
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+
+            this.player1.clickPrompt('Bow loser');
+
+            expect(this.player1).not.toHavePrompt('Choose a card');
+            expect(this.challenger.bowed).toBe(true);
+            expect(this.challenger.location).toBe('play area');
+
+            expect(this.getChatLogs(10)).toContain('player1 chooses to bow Doji Challenger');
+        });
+
+        it('should let you choose to bow even if loser is already bowed', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.challenger.bow();
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.challenger);
+            this.player1.clickCard(this.tanto);
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+
+            expect(this.player1).toHavePromptButton('Sacrifice a weapon to discard loser');
+            expect(this.player1).toHavePromptButton('Bow loser');
+            this.player1.clickPrompt('Bow loser');
+
+            expect(this.player1).not.toHavePrompt('Choose a card');
+            expect(this.challenger.location).toBe('play area');
+
+            expect(this.getChatLogs(10)).toContain('player1 chooses to bow Doji Challenger');
+        });
+
+        it('if you lose the duel should not prompt you to decide if you want to sacrifice a weapon', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.kuwanan);
+            this.player1.clickCard(this.tanto);
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('5');
+
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            expect(this.getChatLogs(10)).toContain('player1 uses Master of the Blade, bowing Inscribed Tantō to initiate a military duel : Master of the Blade vs. Doji Kuwanan');
+            expect(this.getChatLogs(10)).toContain('Duel Effect: bow Master of the Blade');
+        });
+
+        it('if you don\'t have a weapon to sac should not prompt you to decide if you want to sacrifice a weapon', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.kuwanan);
+            this.player1.clickCard(this.tanto);
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+
+            this.player1.clickPrompt('Sacrifice a weapon to discard loser');
+            this.player1.clickCard(this.dragonsFang);
+            this.player2.pass();
+            this.player1.clickCard(this.masterOfTheBlade);
+            this.player1.clickCard(this.challenger);
+            this.player1.clickCard(this.dragonsClaw);
+
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            expect(this.getChatLogs(10)).toContain('player1 uses Master of the Blade, bowing Dragon\'s Claw to initiate a military duel : Master of the Blade vs. Doji Challenger');
+            expect(this.getChatLogs(10)).toContain('Duel Effect: bow Doji Challenger');
+        });
+
+        it('does not work when the Master of the Blade is bowed',function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.masterOfTheBlade, this.raitsugu],
+                defenders: [this.challenger, this.kuwanan]
+            });
+            this.player2.clickCard(this.craneMirumotosFury);
+            this.player2.clickCard(this.masterOfTheBlade);
+
+            expect(this.masterOfTheBlade.bowed).toBe(true);
+            this.player1.clickCard(this.masterOfTheBlade);
+            expect(this.player1).not.toHavePrompt('Choose a character');
+
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/NamelessBrother.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/NamelessBrother.spec.js
@@ -1,0 +1,116 @@
+describe('Nameless Brother', function () {
+    integration(function () {
+        describe('One Nameless Brother', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: [
+                            'nameless-brother',
+                            'togashi-yoshi',
+                            'togashi-initiate',
+                            'togashi-initiate',
+                            'inventive-mirumoto',
+                            'inventive-mirumoto',
+                            'inventive-mirumoto'
+                        ]
+                    }
+                });
+
+                this.namelessBrother =
+                    this.player1.findCardByName('nameless-brother');
+                this.togashiYoshi =
+                    this.player1.findCardByName('togashi-yoshi');
+                this.initiate1 =
+                    this.player1.filterCardsByName('togashi-initiate')[0];
+                this.initiate2 =
+                    this.player1.filterCardsByName('togashi-initiate')[1];
+                this.mirumoto1 =
+                    this.player1.filterCardsByName('inventive-mirumoto')[0];
+                this.mirumoto2 =
+                    this.player1.filterCardsByName('inventive-mirumoto')[1];
+                this.mirumoto3 =
+                    this.player1.filterCardsByName('inventive-mirumoto')[2];
+            });
+
+            it('gives skill bonus to all characters with repeated names', function () {
+                expect(this.namelessBrother.militarySkill).toBe(1);
+                expect(this.namelessBrother.politicalSkill).toBe(1);
+
+                expect(this.togashiYoshi.militarySkill).toBe(1);
+                expect(this.togashiYoshi.politicalSkill).toBe(1);
+
+                expect(this.initiate1.militarySkill).toBe(2);
+                expect(this.initiate1.politicalSkill).toBe(2);
+                expect(this.initiate2.militarySkill).toBe(2);
+                expect(this.initiate2.politicalSkill).toBe(2);
+
+                expect(this.mirumoto1.militarySkill).toBe(3);
+                expect(this.mirumoto1.politicalSkill).toBe(3);
+                expect(this.mirumoto2.militarySkill).toBe(3);
+                expect(this.mirumoto2.politicalSkill).toBe(3);
+                expect(this.mirumoto3.militarySkill).toBe(3);
+                expect(this.mirumoto3.politicalSkill).toBe(3);
+            });
+        });
+
+        describe('Multiple Nameless Brother', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: [
+                            'nameless-brother',
+                            'nameless-brother',
+                            'togashi-yoshi',
+                            'togashi-initiate',
+                            'togashi-initiate',
+                            'inventive-mirumoto',
+                            'inventive-mirumoto',
+                            'inventive-mirumoto'
+                        ]
+                    }
+                });
+
+                this.namelessBrother1 =
+                    this.player1.filterCardsByName('nameless-brother')[0];
+                this.namelessBrother2 =
+                    this.player1.filterCardsByName('nameless-brother')[1];
+                this.togashiYoshi =
+                    this.player1.findCardByName('togashi-yoshi');
+                this.initiate1 =
+                    this.player1.filterCardsByName('togashi-initiate')[0];
+                this.initiate2 =
+                    this.player1.filterCardsByName('togashi-initiate')[1];
+                this.mirumoto1 =
+                    this.player1.filterCardsByName('inventive-mirumoto')[0];
+                this.mirumoto2 =
+                    this.player1.filterCardsByName('inventive-mirumoto')[1];
+                this.mirumoto3 =
+                    this.player1.filterCardsByName('inventive-mirumoto')[2];
+            });
+
+            it('gives skill bonus to all characters with repeated names', function () {
+                expect(this.namelessBrother1.militarySkill).toBe(3);
+                expect(this.namelessBrother1.politicalSkill).toBe(3);
+                expect(this.namelessBrother2.militarySkill).toBe(3);
+                expect(this.namelessBrother2.politicalSkill).toBe(3);
+
+                expect(this.togashiYoshi.militarySkill).toBe(1);
+                expect(this.togashiYoshi.politicalSkill).toBe(1);
+
+                expect(this.initiate1.militarySkill).toBe(3);
+                expect(this.initiate1.politicalSkill).toBe(3);
+                expect(this.initiate2.militarySkill).toBe(3);
+                expect(this.initiate2.politicalSkill).toBe(3);
+
+                expect(this.mirumoto1.militarySkill).toBe(5);
+                expect(this.mirumoto1.politicalSkill).toBe(5);
+                expect(this.mirumoto2.militarySkill).toBe(5);
+                expect(this.mirumoto2.politicalSkill).toBe(5);
+                expect(this.mirumoto3.militarySkill).toBe(5);
+                expect(this.mirumoto3.politicalSkill).toBe(5);
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/PalmStrike.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/PalmStrike.spec.js
@@ -1,0 +1,150 @@
+describe('Palm Strike', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: [
+                        'togashi-ichi',
+                        'doomed-shugenja',
+                        'shrine-maiden'
+                    ],
+                    hand: ['palm-strike', 'ancestral-daisho'],
+                    dynastyDiscard: []
+                },
+                player2: {
+                    inPlay: ['brash-samurai'],
+                    hand: ['kakita-blade', 'elegant-tessen']
+                }
+            });
+
+            this.togashiIchi = this.player1.findCardByName('togashi-ichi');
+            this.doomedShugenja =
+                this.player1.findCardByName('doomed-shugenja');
+            this.shrineMaiden = this.player1.findCardByName('shrine-maiden');
+            this.palmStrike = this.player1.findCardByName('palm-strike');
+            this.ancestralDaisho =
+                this.player1.findCardByName('ancestral-daisho');
+
+            this.brash = this.player2.findCardByName('brash-samurai');
+            this.kakitaBlade = this.player2.findCardByName('kakita-blade');
+            this.elegantTessen = this.player2.findCardByName('elegant-tessen');
+        });
+
+        describe('when the opponent has a weapon', function () {
+            beforeEach(function () {
+                this.player1.pass();
+                this.player2.playAttachment(this.kakitaBlade, this.brash);
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.togashiIchi, this.doomedShugenja],
+                    defenders: [this.brash]
+                });
+            });
+
+            it('should not be playable', function () {
+                this.player2.pass();
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+                this.player1.clickCard(this.palmStrike);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+        });
+
+        describe('when the monk has a weapon', function () {
+            beforeEach(function () {
+                this.player1.playAttachment(
+                    this.ancestralDaisho,
+                    this.togashiIchi
+                );
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.togashiIchi, this.doomedShugenja],
+                    defenders: [this.brash]
+                });
+            });
+
+            it('should not be playable', function () {
+                this.player2.pass();
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+                this.player1.clickCard(this.palmStrike);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+        });
+
+        describe('when an non-tattooed monk and the opponent have no weapons', function () {
+            beforeEach(function () {
+                this.player1.playAttachment(
+                    this.ancestralDaisho,
+                    this.doomedShugenja
+                );
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.shrineMaiden, this.doomedShugenja],
+                    defenders: [this.brash],
+                    ring: 'void'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.palmStrike);
+                this.player1.clickCard(this.shrineMaiden);
+                this.player1.clickCard(this.brash);
+            });
+
+            it('should bow the opponent', function () {
+                expect(this.brash.bowed).toBe(true);
+            });
+
+            it('should not prevent the opponent from readying during the conflict', function () {
+                this.player2.clickCard(this.elegantTessen);
+                this.player2.clickCard(this.brash);
+                this.player2.clickCard(this.elegantTessen);
+                expect(this.brash.bowed).toBe(false);
+            });
+
+            it('displays messages', function () {
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 plays Palm Strike to bow Brash Samurai — they are stricken down by the Shrine Maiden.'
+                );
+            });
+        });
+
+        describe('when a tattooed monk and the opponent have no weapons', function () {
+            beforeEach(function () {
+                this.player1.playAttachment(
+                    this.ancestralDaisho,
+                    this.doomedShugenja
+                );
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.togashiIchi, this.doomedShugenja],
+                    defenders: [this.brash],
+                    ring: 'void'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.palmStrike);
+                this.player1.clickCard(this.togashiIchi);
+                this.player1.clickCard(this.brash);
+            });
+
+            it('should bow the opponent', function () {
+                expect(this.brash.bowed).toBe(true);
+            });
+
+            it('should prevent the opponent from readying until the end of the conflict', function () {
+                this.player2.clickCard(this.elegantTessen);
+                this.player2.clickCard(this.brash);
+                expect(this.player2).toHavePrompt(
+                    'Waiting for opponent to take an action or pass'
+                );
+                expect(this.brash.bowed).toBe(true);
+            });
+
+            it('displays messages', function () {
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 plays Palm Strike to bow Brash Samurai — they are overwhelmed by the mystical tattoos of Togashi Ichi.'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/SeijisFate.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/SeijisFate.spec.js
@@ -1,0 +1,66 @@
+describe('Seijis Fate', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['bayushi-shoju'],
+                    hand: ['a-new-name', 'seiji-s-fate']
+                },
+                player2: {
+                    inPlay: ['doji-challenger']
+                }
+            });
+            this.shoju = this.player1.findCardByName('bayushi-shoju');
+            this.ann = this.player1.findCardByName('a-new-name');
+            this.seiji = this.player1.findCardByName('seiji-s-fate');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'political',
+                attackers: [this.shoju],
+                defenders: [this.challenger]
+            });
+            this.player2.pass();
+        });
+
+        it('should remove traits and add creature', function () {
+            expect(this.shoju.hasTrait('champion')).toBe(true);
+            expect(this.shoju.hasTrait('courtier')).toBe(true);
+            expect(this.shoju.hasTrait('bushi')).toBe(true);
+            expect(this.shoju.hasTrait('creature')).toBe(false);
+
+            this.player1.playAttachment(this.seiji, this.shoju);
+
+            expect(this.shoju.hasTrait('champion')).toBe(true);
+            expect(this.shoju.hasTrait('courtier')).toBe(false);
+            expect(this.shoju.hasTrait('bushi')).toBe(false);
+            expect(this.shoju.hasTrait('creature')).toBe(true);
+        });
+
+        it('should blank', function () {
+            this.player1.playAttachment(this.seiji, this.shoju);
+            this.player2.pass();
+            expect(this.player1).toHavePrompt('Conflict Action Window');
+            this.player1.clickCard(this.shoju);
+            expect(this.player1).toHavePrompt('Conflict Action Window');
+        });
+
+        it('should remove gained traits', function () {
+            this.player1.playAttachment(this.ann, this.challenger);
+            expect(this.challenger.hasTrait('bushi')).toBe(true);
+            expect(this.challenger.hasTrait('duelist')).toBe(true);
+            expect(this.challenger.hasTrait('courtier')).toBe(true);
+            expect(this.challenger.hasTrait('creature')).toBe(false);
+
+            this.player2.pass();
+            this.player1.playAttachment(this.seiji, this.challenger);
+
+            expect(this.challenger.hasTrait('bushi')).toBe(false);
+            expect(this.challenger.hasTrait('duelist')).toBe(true);
+            expect(this.challenger.hasTrait('courtier')).toBe(false);
+            expect(this.challenger.hasTrait('creature')).toBe(true);
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Dragon/VillageDoshin.spec.js
+++ b/test/server/cards/19.1-AS01/Dragon/VillageDoshin.spec.js
@@ -1,0 +1,144 @@
+describe('Village Doshin', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['mirumoto-raitsugu'],
+                    hand: ['fine-katana', 'dragon-s-fang', 'dragon-s-claw', 'village-doshin']
+                },
+                player2: {
+                    inPlay: ['keeper-initiate'],
+                    dynastyDiscard: ['chukan-nobue'],
+                    hand: ['let-go', 'clarity-of-purpose', 'against-the-waves']
+                }
+            });
+
+            this.raitsugu = this.player1.findCardByName('mirumoto-raitsugu');
+
+            this.dragonsClaw = this.player1.findCardByName('dragon-s-claw');
+            this.dragonsFang = this.player1.findCardByName('dragon-s-fang');
+            this.fineKatana = this.player1.findCardByName('fine-katana');
+            this.villageDoshin = this.player1.findCardByName('village-doshin');
+
+            this.keeperInitiate = this.player2.findCardByName('keeper-initiate');
+            this.chukanNobue = this.player2.findCardByName('chukan-nobue');
+            this.letGo = this.player2.findCardByName('let-go');
+            this.clarity = this.player2.findCardByName('clarity-of-purpose');
+            this.againstTheWaves = this.player2.findCardByName('against-the-waves');
+        });
+
+        it('should trigger when an attachment is target', function () {
+            this.player1.clickCard(this.fineKatana);
+            this.player1.clickCard(this.raitsugu);
+
+            this.player2.clickCard(this.letGo);
+            this.player2.clickCard(this.fineKatana);
+
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+        });
+
+        it('saves the attachment if the opponent refuses to pay the added cost', function () {
+            this.player1.clickCard(this.fineKatana);
+            this.player1.clickCard(this.raitsugu);
+
+            this.player2.clickCard(this.letGo);
+            this.player2.clickCard(this.fineKatana);
+
+            this.player1.clickCard(this.villageDoshin);
+            expect(this.player2).toHavePrompt('Select one');
+            expect(this.player2).toHavePromptButton('Discard 2 random cards from hand');
+            expect(this.player2).toHavePromptButton('Let the effect be canceled');
+
+            this.player2.clickPrompt('Let the effect be canceled');
+            expect(this.villageDoshin.location).toBe('conflict discard pile');
+            expect(this.letGo.location).toBe('conflict discard pile');
+            expect(this.fineKatana.location).toBe('play area');
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Village Dōshin, discarding Village Dōshin to protect Fine Katana'
+            );
+            expect(this.getChatLogs(5)).toContain(
+                'player2 refuses to discard 2 cards. The effects of Let Go are canceled.'
+            );
+        });
+
+        it('saves the attachment if the opponent does not have fate to pay the added cost', function () {
+            this.player1.moveCard(this.againstTheWaves, 'conflict discard pile');
+
+            this.player1.clickCard(this.fineKatana);
+            this.player1.clickCard(this.raitsugu);
+
+            this.player2.clickCard(this.letGo);
+            this.player2.clickCard(this.fineKatana);
+
+            this.player1.clickCard(this.villageDoshin);
+            expect(this.player2).not.toHavePrompt('Select one');
+            expect(this.villageDoshin.location).toBe('conflict discard pile');
+            expect(this.letGo.location).toBe('conflict discard pile');
+            expect(this.fineKatana.location).toBe('play area');
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Village Dōshin, discarding Village Dōshin to protect Fine Katana'
+            );
+        });
+
+        it('saves the attachment if the opponent cannot pay the added cost', function () {
+            this.player2.moveCard(this.chukanNobue, 'play area');
+
+            this.player1.clickCard(this.fineKatana);
+            this.player1.clickCard(this.raitsugu);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.raitsugu],
+                defenders: []
+            });
+
+            this.player2.clickCard(this.letGo);
+            this.player2.clickCard(this.fineKatana);
+
+            this.player1.clickCard(this.villageDoshin);
+            expect(this.player2.fate).toBeGreaterThanOrEqual(1);
+            expect(this.player2).not.toHavePrompt('Select one');
+            expect(this.villageDoshin.location).toBe('conflict discard pile');
+            expect(this.letGo.location).toBe('conflict discard pile');
+            expect(this.fineKatana.location).toBe('play area');
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Village Dōshin, discarding Village Dōshin to protect Fine Katana'
+            );
+        });
+
+        it('does not save the attachment if the opponent pays the added cost', function () {
+            this.player1.clickCard(this.dragonsClaw);
+            this.player1.clickCard(this.raitsugu);
+
+            this.player2.clickCard(this.letGo);
+            this.player2.clickCard(this.dragonsClaw);
+
+            this.player1.clickCard(this.villageDoshin);
+            expect(this.player2).toHavePrompt('Select one');
+            expect(this.player2).toHavePromptButton('Discard 2 random cards from hand');
+            expect(this.player2).toHavePromptButton('Let the effect be canceled');
+
+            this.player2.clickPrompt('Discard 2 random cards from hand');
+            expect(this.villageDoshin.location).toBe('conflict discard pile');
+            expect(this.letGo.location).toBe('conflict discard pile');
+            expect(this.dragonsClaw.location).toBe('conflict discard pile');
+            expect(this.againstTheWaves.location).toBe('conflict discard pile');
+            expect(this.clarity.location).toBe('conflict discard pile');
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Village Dōshin, discarding Village Dōshin to protect Dragon\'s Claw'
+            );
+            expect(this.getChatLogs(5)).toContain('player2 distracts the Dōshin.');
+        });
+
+        it('does not save attachments on characters controlled by another player', function () {
+            this.player1.clickCard(this.dragonsClaw);
+            this.player1.clickCard(this.keeperInitiate);
+
+            this.player2.clickCard(this.letGo);
+            this.player2.clickCard(this.dragonsClaw);
+
+            expect(this.player1).not.toHavePrompt('Triggered Abilities');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/CornerThePrey.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/CornerThePrey.spec.js
@@ -1,0 +1,128 @@
+describe('Corner the Prey', function () {
+    integration(function () {
+        describe('Corner the Prey action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        fate: 500,
+                        inPlay: ['doji-challenger', 'doji-whisperer', 'ikoma-message-runner'],
+                        hand: ['corner-the-prey', 'fine-katana', 'ayubune-pilot', 'dutiful-assistant']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar', 'agasha-prodigy', 'akodo-makoto', 'akodo-kage', 'akodo-cho']
+                    }
+                });
+
+                this.challenger = this.player1.findCardByName('doji-challenger');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.whisperer = this.player1.findCardByName('doji-whisperer');
+
+                this.cornerThePrey = this.player1.findCardByName('corner-the-prey');
+                this.ayubunePilot = this.player1.findCardByName('ayubune-pilot');
+                this.fineKatana = this.player1.findCardByName('fine-katana');
+                this.assistant = this.player1.findCardByName('dutiful-assistant');
+
+                this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+                this.agashaProdigy = this.player2.findCardByName('agasha-prodigy');
+                this.akodoMakoto = this.player2.findCardByName('akodo-makoto');
+                this.akodoKage = this.player2.findCardByName('akodo-kage');
+                this.akodoCho = this.player2.findCardByName('akodo-cho');
+
+                this.player1.playAttachment(this.fineKatana, this.messageRunner);
+                this.player2.pass();
+                this.player1.playAttachment(this.ayubunePilot, this.messageRunner);
+                this.player2.pass();
+                this.player1.playAttachment(this.assistant, this.whisperer);
+            });
+
+            it('should not be playable with no participating follower cards', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.challenger],
+                    defenders: [this.solemnScholar, this.agashaProdigy, this.akodoMakoto, this.akodoKage, this.akodoCho]
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.cornerThePrey);
+
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should prompt you to sacrifice followers', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.messageRunner],
+                    defenders: [this.solemnScholar, this.agashaProdigy, this.akodoMakoto, this.akodoKage, this.akodoCho]
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.cornerThePrey);
+
+                expect(this.player1).toHavePrompt('Select card to sacrifice');
+                expect(this.player1).toBeAbleToSelect(this.ayubunePilot);
+                expect(this.player1).not.toBeAbleToSelect(this.fineKatana);
+                expect(this.player1).not.toBeAbleToSelect(this.assistant);
+                expect(this.player1).not.toHavePromptButton('Done');
+            });
+
+            it('should prompt you to choose a participating character with printed cost less than # of sacrificed and discard it', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.messageRunner],
+                    defenders: [this.solemnScholar, this.agashaProdigy, this.akodoMakoto, this.akodoKage, this.akodoCho]
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.cornerThePrey);
+                this.player1.clickCard(this.ayubunePilot);
+                this.player1.clickPrompt('Done');
+
+                expect(this.player1).toHavePrompt('Choose a character');
+
+                expect(this.player1).toBeAbleToSelect(this.messageRunner);
+                expect(this.player1).not.toBeAbleToSelect(this.whisperer);
+                expect(this.player1).not.toBeAbleToSelect(this.challenger);
+                expect(this.player1).toBeAbleToSelect(this.solemnScholar);
+                expect(this.player1).not.toBeAbleToSelect(this.agashaProdigy);
+                expect(this.player1).not.toBeAbleToSelect(this.akodoMakoto);
+                expect(this.player1).not.toBeAbleToSelect(this.akodoKage);
+                expect(this.player1).not.toBeAbleToSelect(this.akodoCho);
+
+                this.player1.clickCard(this.solemnScholar);
+                expect(this.solemnScholar.location).toBe('dynasty discard pile');
+                expect(this.getChatLogs(5)).toContain('player1 plays Corner the Prey, sacrificing Ayubune Pilot to discard Solemn Scholar');
+            });
+
+            it('should let you sacrifice multiple followers', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.messageRunner, this.whisperer],
+                    defenders: [this.solemnScholar, this.agashaProdigy, this.akodoMakoto, this.akodoKage, this.akodoCho]
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.cornerThePrey);
+                this.player1.clickCard(this.ayubunePilot);
+                this.player1.clickCard(this.assistant);
+                this.player1.clickPrompt('Done');
+
+                expect(this.player1).toHavePrompt('Choose a character');
+
+                expect(this.player1).toBeAbleToSelect(this.solemnScholar);
+                expect(this.player1).toBeAbleToSelect(this.agashaProdigy);
+                expect(this.player1).not.toBeAbleToSelect(this.akodoMakoto);
+                expect(this.player1).not.toBeAbleToSelect(this.akodoKage);
+                expect(this.player1).not.toBeAbleToSelect(this.akodoCho);
+
+                this.player1.clickCard(this.solemnScholar);
+                expect(this.solemnScholar.location).toBe('dynasty discard pile');
+                expect(this.getChatLogs(5)).toContain('player1 plays Corner the Prey, sacrificing Ayubune Pilot and Dutiful Assistant to discard Solemn Scholar');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/FortunesField.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/FortunesField.spec.js
@@ -1,0 +1,121 @@
+const GameModes = require('../../../../../server/GameModes');
+
+describe('Fortunes Field', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'dynasty',
+                player1: {
+                    fate: 30,
+                    dynastyDiscard: ['kakita-yoshi', 'kakita-toshimoko', 'daidoji-kageyu', 'moto-chagatai'],
+                    hand: ['ageless-crone', 'dutiful-assistant', 'watch-commander'],
+                    provinces: ['fortune-s-field', 'manicured-garden']
+                },
+                gameMode: GameModes.Emerald
+            });
+
+            this.field = this.player1.findCardByName('fortune-s-field', 'province 1');
+            this.manicured = this.player1.findCardByName('manicured-garden', 'province 2');
+            this.yoshi = this.player1.placeCardInProvince('kakita-yoshi', this.field.location);
+            this.toshimoko = this.player1.placeCardInProvince('kakita-toshimoko', 'province 2');
+            this.kageyu = this.player1.moveCard('daidoji-kageyu', this.field.location);
+            this.chagatai = this.player1.moveCard('moto-chagatai', this.field.location);
+            this.crone = this.player1.findCardByName('ageless-crone');
+            this.assistant = this.player1.findCardByName('dutiful-assistant');
+            this.commander = this.player1.findCardByName('watch-commander');
+        });
+
+        it('should react after playing a character from self', function() {
+            this.player1.clickCard(this.yoshi);
+            this.player1.clickPrompt('0');
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.field);
+            this.player1.clickCard(this.field);
+            expect(this.getChatLogs(5)).toContain('player1 uses Fortune\'s Field to reduce the cost of their next character or follower this round by 1');
+        });
+
+        it('should react after playing a character from another province', function() {
+            this.player1.clickCard(this.toshimoko);
+            this.player1.clickPrompt('0');
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.field);
+        });
+
+        it('should react after playing a character from hand (dynasty)', function() {
+            this.player1.clickCard(this.crone);
+            this.player1.clickPrompt('0');
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.field);
+        });
+
+        it('reduces next character', function() {
+            this.player1.clickCard(this.yoshi);
+            this.player1.clickPrompt('0');
+            this.player1.clickCard(this.field);
+            this.player2.pass();
+
+            let fate = this.player1.fate;
+            let cost = this.toshimoko.printedCost;
+
+            this.player1.clickCard(this.toshimoko);
+            this.player1.clickPrompt('0');
+            expect(this.player1.fate).toBe(fate - (cost - 1));
+
+            fate = this.player1.fate;
+            cost = this.chagatai.printedCost;
+
+            this.player1.clickCard(this.chagatai);
+            this.player1.clickPrompt('0');
+            expect(this.player1.fate).toBe(fate - cost);
+        });
+
+        it('reduces next follower', function() {
+            this.player1.clickCard(this.yoshi);
+            this.player1.clickPrompt('0');
+            this.player1.clickCard(this.field);
+            this.player2.pass();
+
+            let fate = this.player1.fate;
+            let cost = this.assistant.printedCost;
+
+            this.player1.clickCard(this.assistant);
+            this.player1.clickCard(this.yoshi);
+            expect(this.player1.fate).toBe(fate - (cost - 1));
+
+            fate = this.player1.fate;
+            cost = this.commander.printedCost;
+
+            this.player1.clickCard(this.commander);
+            this.player1.clickCard(this.yoshi);
+            expect(this.player1.fate).toBe(fate - cost);
+        });
+
+        it('reduction should carry into the next phase', function() {
+            this.player1.clickCard(this.yoshi);
+            this.player1.clickPrompt('0');
+            this.player1.clickCard(this.field);
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('1');
+            this.player2.clickPrompt('1');
+
+            let fate = this.player1.fate;
+            let cost = this.crone.printedCost;
+
+            this.player1.clickCard(this.crone);
+            this.player1.clickPrompt('0');
+            expect(this.player1.fate).toBe(fate - (cost - 1));
+
+            expect(this.crone.location).toBe('play area');
+            this.player2.pass();
+
+            fate = this.player1.fate;
+            cost = this.commander.printedCost;
+
+            this.player1.clickCard(this.commander);
+            this.player1.clickCard(this.yoshi);
+            expect(this.player1.fate).toBe(fate - cost);
+            expect(this.commander.location).toBe('play area');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/IkomaMasterHunter.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/IkomaMasterHunter.spec.js
@@ -1,0 +1,131 @@
+describe('Ikoma Master Hunter', function () {
+    integration(function () {
+        describe('Ikoma Master Hunter reaction ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'draw',
+                    player1: {
+                        inPlay: ['ikoma-master-hunter']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar', 'shinjo-outrider']
+                    }
+                });
+
+                this.ikomaMasterHunter = this.player1.findCardByName('ikoma-master-hunter');
+                this.scholar = this.player2.findCardByName('solemn-scholar');
+                this.outrider = this.player2.findCardByName('shinjo-outrider');
+                this.ikomaMasterHunter.bow();
+
+                this.player1.clickPrompt('1');
+                this.player2.clickPrompt('1');
+            });
+
+            it('should trigger on conflict phase start and let you select a opponent character', function () {
+                this.noMoreActions();
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.ikomaMasterHunter);
+
+                this.player1.clickCard(this.ikomaMasterHunter);
+
+                expect(this.player1).not.toBeAbleToSelect(this.ikomaMasterHunter);
+                expect(this.player1).toBeAbleToSelect(this.scholar);
+                expect(this.player1).toBeAbleToSelect(this.outrider);
+
+                this.player1.clickCard(this.scholar);
+                expect(this.getChatLogs(3)).toContain('player1 uses Ikoma Master Hunter to track Solemn Scholar');
+            });
+
+
+            it('should move in and ready the master hunter when the targeted character commits to a conflict', function () {
+                this.noMoreActions();
+
+                this.player1.clickCard(this.ikomaMasterHunter);
+                this.player1.clickCard(this.scholar);
+
+                this.noMoreActions();
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    type: 'political',
+                    attackers: [this.scholar],
+                    defenders: []
+                });
+
+                expect(this.player1).toHavePrompt('conflict action window');
+                expect(this.ikomaMasterHunter.isParticipating()).toBe(true);
+                expect(this.ikomaMasterHunter.bowed).toBe(false);
+            });
+
+            it('should move in and ready the master hunter when the targeted character moves to a conflict', function () {
+                this.noMoreActions();
+
+                this.player1.clickCard(this.ikomaMasterHunter);
+                this.player1.clickCard(this.outrider);
+
+                this.noMoreActions();
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    type: 'political',
+                    attackers: [this.scholar],
+                    defenders: []
+                });
+
+                expect(this.ikomaMasterHunter.isParticipating()).toBe(false);
+                expect(this.ikomaMasterHunter.bowed).toBe(true);
+
+                this.player1.pass();
+                this.player2.clickCard(this.outrider);
+
+                expect(this.outrider.isParticipating()).toBe(true);
+                expect(this.outrider.bowed).toBe(false);
+
+                expect(this.player1).toHavePrompt('conflict action window');
+                expect(this.ikomaMasterHunter.isParticipating()).toBe(true);
+                expect(this.ikomaMasterHunter.bowed).toBe(false);
+            });
+
+            it('should activate multiple times per turn', function () {
+                this.noMoreActions();
+
+                this.player1.clickCard(this.ikomaMasterHunter);
+                this.player1.clickCard(this.scholar);
+
+                this.noMoreActions();
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    type: 'political',
+                    ring: 'air',
+                    attackers: [this.scholar],
+                    defenders: []
+                });
+
+                expect(this.player1).toHavePrompt('conflict action window');
+                expect(this.ikomaMasterHunter.isParticipating()).toBe(true);
+                expect(this.ikomaMasterHunter.bowed).toBe(false);
+
+                this.player1.pass();
+                this.player2.pass();
+
+                this.scholar.ready();
+                this.game.checkGameState(true);
+                this.noMoreActions();
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    type: 'military',
+                    ring: 'fire',
+                    attackers: [this.scholar],
+                    defenders: []
+                });
+
+                expect(this.player1).toHavePrompt('conflict action window');
+                expect(this.ikomaMasterHunter.isParticipating()).toBe(true);
+                expect(this.ikomaMasterHunter.bowed).toBe(false);
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/Kinki.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/Kinki.spec.js
@@ -1,0 +1,144 @@
+describe('Kinki', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: [
+                        'shinjo-outrider',
+                        'aggressive-moto',
+                        'iuchi-wayfinder',
+                        'kakita-toshimoko',
+                        'doji-challenger'
+                    ]
+                },
+                player2: {
+                    inPlay: ['relentless-inquisitor'],
+                    hand: ['kinki']
+                }
+            });
+            this.outrider = this.player1.findCardByName('shinjo-outrider');
+            this.moto = this.player1.findCardByName('aggressive-moto');
+            this.wayfinder = this.player1.findCardByName('iuchi-wayfinder');
+            this.toshimoko = this.player1.findCardByName('kakita-toshimoko');
+            this.challenger = this.player1.findCardByName('doji-challenger');
+
+            this.inquisitor = this.player2.findCardByName('relentless-inquisitor');
+            this.kinki = this.player2.findCardByName('kinki');
+
+            this.outrider.fate = 1;
+            this.challenger.fate = 1;
+
+            this.player1.pass();
+            this.player2.playAttachment(this.kinki, this.inquisitor);
+        });
+
+        it('should allow targeting a participating character eligible for the effect', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.outrider, this.moto, this.toshimoko],
+                defenders: [this.inquisitor],
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.kinki);
+            expect(this.player2).toBeAbleToSelect(this.outrider);
+            expect(this.player2).toBeAbleToSelect(this.moto);
+            expect(this.player2).toBeAbleToSelect(this.toshimoko);
+            expect(this.player2).not.toBeAbleToSelect(this.challenger); // not participating
+            expect(this.player2).not.toBeAbleToSelect(this.wayfinder); // not participating
+            expect(this.player2).not.toBeAbleToSelect(this.inquisitor); // not controlled by opponent
+        });
+
+        it('should give you a choice if both effects can impact the target', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.outrider, this.moto],
+                defenders: [this.inquisitor],
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.kinki);
+            this.player2.clickCard(this.outrider);
+            expect(this.player1).toHavePromptButton('Remove a fate from this character');
+            expect(this.player1).toHavePromptButton('Move this character home');
+        });
+
+        it('should remove a fate if selected', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.outrider, this.moto],
+                defenders: [this.inquisitor],
+                type: 'military'
+            });
+
+            let fate = this.outrider.fate;
+            this.player2.clickCard(this.kinki);
+            this.player2.clickCard(this.outrider);
+            this.player1.clickPrompt('Remove a fate from this character');
+            expect(this.outrider.fate).toBe(fate - 1);
+            expect(this.outrider.isParticipating()).toBe(true);
+            expect(this.kinki.location).toBe('conflict discard pile');
+            expect(this.getChatLogs(5)).toContain(
+                'player2 uses Kinki, sacrificing Kinki to remove 1 fate from Shinjo Outrider'
+            );
+        });
+
+        it('should move home if selected', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.outrider, this.moto],
+                defenders: [this.inquisitor]
+            });
+
+            let fate = this.outrider.fate;
+            this.player2.clickCard(this.kinki);
+            this.player2.clickCard(this.outrider);
+            this.player1.clickPrompt('Move this character home');
+            expect(this.outrider.fate).toBe(fate);
+            expect(this.outrider.isParticipating()).toBe(false);
+            expect(this.getChatLogs(5)).toContain('player2 uses Kinki, sacrificing Kinki to send Shinjo Outrider home');
+        });
+
+        it('should not give you a choice if target has no fate', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.outrider, this.moto],
+                defenders: [this.inquisitor]
+            });
+
+            this.player2.clickCard(this.kinki);
+            this.player2.clickCard(this.moto);
+            expect(this.player1).not.toHavePromptButton('Remove a fate from this character');
+            expect(this.player1).not.toHavePromptButton('Move this character home');
+            expect(this.moto.isParticipating()).toBe(false);
+            expect(this.getChatLogs(5)).toContain('player2 uses Kinki, sacrificing Kinki to send Aggressive Moto home');
+        });
+
+        it('should not work in a pol conflict', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.outrider, this.moto, this.toshimoko],
+                defenders: [this.inquisitor],
+                type: 'political'
+            });
+
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            this.player2.clickCard(this.kinki);
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+        });
+
+        it('should not work if parent is not participating', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.outrider, this.moto, this.toshimoko],
+                defenders: [],
+                type: 'military'
+            });
+
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            this.player2.clickCard(this.kinki);
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/PlantedFields.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/PlantedFields.spec.js
@@ -1,0 +1,55 @@
+describe('Planted Fields', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['vanguard-warrior'],
+                    dynastyDiscard: ['planted-fields']
+                },
+                player2: {
+                    inPlay: ['vanguard-warrior']
+                }
+            });
+
+            this.plantedFields = this.player1.findCardByName('planted-fields');
+            this.shameful = this.player1.findCardByName('shameful-display', 'province 1');
+            this.player1.placeCardInProvince(this.plantedFields, 'province 1');
+
+            this.noMoreActions();
+            this.player1.passConflict();
+            this.noMoreActions();
+            this.player2.passConflict();
+            this.noMoreActions();
+            this.player1.passConflict();
+            this.noMoreActions();
+            this.player2.passConflict();
+        });
+
+        it('should trigger at the end of the conflict phase if it is in an unbroken province', function() {
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.plantedFields);
+        });
+
+        it('should not trigger at the end of the conflict phase if it is in a broken province', function() {
+            this.shameful.isBroken = true;
+            this.noMoreActions();
+            expect(this.player1).not.toHavePrompt('Triggered Abilities');
+        });
+
+        it('should sacrifice itself to give 2 fate and draw 2 cards', function() {
+            let honor = this.player1.honor;
+            let fate = this.player1.fate;
+            let handSize = this.player1.hand.length;
+            this.noMoreActions();
+            this.player1.clickCard(this.plantedFields);
+
+            expect(this.player1.honor).toBe(honor);
+            expect(this.player1.fate).toBe(fate + 2);
+            expect(this.player1.hand.length).toBe(handSize + 2);
+            expect(this.plantedFields.location).toBe('dynasty discard pile');
+            expect(this.getChatLogs(5)).toContain('player1 uses Planted Fields, sacrificing Planted Fields to gain 2 fate and draw 2 cards');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/PromisingHohei.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/PromisingHohei.spec.js
@@ -1,0 +1,122 @@
+describe('Promising Hohei', function () {
+    integration(function () {
+        describe('Promising Hohei enter play ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['relentless-gloryseeker', 'ikoma-message-runner'],
+                        hand: ['promising-hohei', 'ayubune-pilot', 'fine-katana', 'promising-hohei', 'ornate-fan'],
+                        stronghold: ['pride']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar'],
+                        hand: ['ayubune-pilot']
+                    }
+                });
+
+                this.pride = this.player1.findCardByName('pride');
+                this.relentlessGloryseeker = this.player1.findCardByName('relentless-gloryseeker');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.promisingHohei1 = this.player1.filterCardsByName('promising-hohei')[0];
+                this.promisingHohei2 = this.player1.filterCardsByName('promising-hohei')[1];
+                this.fan = this.player1.findCardByName('ornate-fan');
+                this.player1.moveCard(this.fan, 'conflict deck');
+
+                this.ayubunePilot1 = this.player1.findCardByName('ayubune-pilot');
+                this.fineKatana = this.player1.findCardByName('fine-katana');
+
+                this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+                this.ayubunePilot2 = this.player2.findCardByName('ayubune-pilot');
+            });
+
+            it('should cost 0 if target has 2 glory', function () {
+                let fate = this.player1.fate;
+
+                this.player1.clickCard(this.promisingHohei1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                expect(this.player1.fate).toBe(fate);
+            });
+
+            it('should cost 1 if target has <2 glory', function () {
+                let fate = this.player1.fate;
+
+                this.player1.clickCard(this.promisingHohei1);
+                this.player1.clickCard(this.messageRunner);
+
+                expect(this.player1.fate).toBe(fate - 1);
+            });
+
+            it('should not trigger if there is no follower attachment', function () {
+                this.player1.clickCard(this.fineKatana);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.promisingHohei1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                expect(this.player1).not.toHavePrompt('Triggered Abilities');
+                expect(this.player2).toHavePrompt('Action Window');
+            });
+
+            it('should prompt to return a follower you control back to hand', function () {
+                this.player1.clickCard(this.ayubunePilot1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                this.player2.clickCard(this.ayubunePilot2);
+                this.player2.clickCard(this.solemnScholar);
+
+                this.player1.clickCard(this.promisingHohei1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.promisingHohei1);
+
+                this.player1.clickCard(this.promisingHohei1);
+                expect(this.player1).toBeAbleToSelect(this.ayubunePilot1);
+                expect(this.player1).not.toBeAbleToSelect(this.ayubunePilot2);
+
+                this.player1.clickCard(this.ayubunePilot1);
+                expect(this.ayubunePilot1.location).toBe('hand');
+            });
+
+            it('cannot return cards named Promising Hohei', function () {
+                this.player1.clickCard(this.ayubunePilot1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+                this.player2.pass();
+                this.player1.clickCard(this.promisingHohei1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+                this.player1.clickPrompt('Pass'); // First Hohei
+                this.player2.pass();
+                this.player1.clickCard(this.promisingHohei2);
+                this.player1.clickCard(this.messageRunner);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(this.promisingHohei2);
+
+                this.player1.clickCard(this.promisingHohei2);
+                expect(this.player1).toBeAbleToSelect(this.ayubunePilot1);
+                expect(this.player1).not.toBeAbleToSelect(this.promisingHohei1);
+
+                this.player1.clickCard(this.ayubunePilot1);
+                expect(this.ayubunePilot1.location).toBe('hand');
+            });
+
+            it('returns soldier tokens to hand', function () {
+                this.player1.clickCard(this.pride);
+                this.player1.clickCard(this.relentlessGloryseeker);
+                const soldier = this.relentlessGloryseeker.attachments.last();
+
+                this.player2.pass();
+                this.player1.clickCard(this.promisingHohei1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                this.player1.clickCard(this.promisingHohei1);
+                this.player1.clickCard(soldier);
+                expect(this.fan.location).toBe('hand');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/RelentlessGloryseeker.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/RelentlessGloryseeker.spec.js
@@ -1,0 +1,112 @@
+describe('Relentless Gloryseeker', function () {
+    integration(function () {
+        describe('Relentless Gloryseeker Reaction Ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: [
+                            'relentless-gloryseeker',
+                            'ikoma-message-runner'
+                        ],
+                        hand: ['embrace-death','assassination']
+                    },
+                    player2: {
+                        inPlay: ['moto-chagatai'],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.relentlessGloryseeker = this.player1.findCardByName(
+                    'relentless-gloryseeker'
+                );
+                this.messageRunner = this.player1.findCardByName(
+                    'ikoma-message-runner'
+                );
+                this.assassinationP1 = this.player1.findCardByName('assassination');
+                this.embraceDeath =
+                    this.player1.findCardByName('embrace-death');
+                this.chagatai = this.player2.findCardByName('moto-chagatai');
+                this.assassinationP2 =
+                    this.player2.findCardByName('assassination');
+            });
+
+            it('returns to play after being sacrificed', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.relentlessGloryseeker, this.messageRunner],
+                    defenders: [this.chagatai]
+                });
+
+                this.player2.pass();
+                this.player1.pass();
+
+                this.player1.clickCard(this.embraceDeath);
+                this.player1.clickCard(this.chagatai);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(
+                    this.relentlessGloryseeker
+                );
+
+                this.player1.clickCard(this.relentlessGloryseeker);
+                expect(this.relentlessGloryseeker.location).toBe('play area');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Relentless Gloryseeker to return to play - Relentless Gloryseeker is ready for more!'
+                );
+            });
+
+            it('returns to play after being discarded by opponent', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.relentlessGloryseeker, this.messageRunner],
+                    defenders: [this.chagatai]
+                });
+
+                this.player2.clickCard(this.assassinationP2);
+                this.player2.clickCard(this.relentlessGloryseeker);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                expect(this.player1).toBeAbleToSelect(
+                    this.relentlessGloryseeker
+                );
+
+                this.player1.clickCard(this.relentlessGloryseeker);
+                expect(this.relentlessGloryseeker.location).toBe('play area');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Relentless Gloryseeker to return to play - Relentless Gloryseeker is ready for more!'
+                );
+            });
+
+            it('is removed from play after 2nd leave from play', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'military',
+                    element:'void',
+                    attackers: [this.relentlessGloryseeker, this.messageRunner],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.assassinationP2);
+                this.player2.clickCard(this.relentlessGloryseeker);
+
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                this.player1.clickCard(this.relentlessGloryseeker);
+                expect(this.relentlessGloryseeker.location).toBe('play area');
+
+                this.player1.clickCard(this.assassinationP1);
+                this.player1.clickCard(this.relentlessGloryseeker);
+
+                expect(this.player1).not.toHavePrompt('Triggered Abilities');
+                expect(this.relentlessGloryseeker.location).toBe('removed from game');
+
+                expect(this.getChatLogs(5)).toContain(
+                    'Relentless Gloryseeker is removed from the game due to leaving play - may their tales lead them to Yomi'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Lion/TheLionsShadow.spec.js
+++ b/test/server/cards/19.1-AS01/Lion/TheLionsShadow.spec.js
@@ -1,0 +1,145 @@
+describe('The Lions Shadow', function () {
+    integration(function () {
+        describe('The Lions Shadow play restriction', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['matsu-berserker', 'ikoma-message-runner','meticulous-scout'],
+                        hand: ['the-lion-s-shadow'],
+                        conflictDeck: ['way-of-the-lion', 'for-shame']
+                    }
+                });
+
+                this.berserker = this.player1.findCardByName('matsu-berserker');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.scout = this.player1.findCardByName('meticulous-scout');
+                this.lionsShadow = this.player1.findCardByName('the-lion-s-shadow');
+                this.berserker.bow();
+            });
+
+            it('should only be able to be played on a courtier or scout', function () {
+                this.player1.clickCard(this.lionsShadow);
+                expect(this.player1).not.toBeAbleToSelect(this.berserker);
+                expect(this.player1).toBeAbleToSelect(this.messageRunner);
+                expect(this.player1).toBeAbleToSelect(this.scout);
+
+                this.player1.clickCard(this.messageRunner);
+                expect(this.getChatLogs(5)).toContain('player1 plays The Lion\'s Shadow, attaching it to Ikoma Message Runner');
+            });
+        });
+
+        describe('The Lions Shadow dishonor token interaction', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['matsu-berserker', 'ikoma-message-runner'],
+                        hand: ['the-lion-s-shadow']
+                    }
+                });
+
+                this.berserker = this.player1.findCardByName('matsu-berserker');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.lionsShadow = this.player1.findCardByName('the-lion-s-shadow');
+                this.messageRunner.dishonor();
+                this.game.checkGameState(true);
+            });
+
+            it('should make it so glory isn\'t affecting when dishonored', function () {
+                expect(this.messageRunner.getPoliticalSkill()).toBe(0);
+
+                this.player1.clickCard(this.lionsShadow);
+                this.player1.clickCard(this.messageRunner);
+
+                expect(this.messageRunner.getPoliticalSkill()).toBe(1);
+            });
+        });
+
+        describe('The Lions Shadow fate phase ancestral keyword', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['matsu-berserker', 'ikoma-message-runner'],
+                        hand: ['the-lion-s-shadow']
+                    }
+                });
+
+                this.berserker = this.player1.findCardByName('matsu-berserker');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.lionsShadow = this.player1.findCardByName('the-lion-s-shadow');
+                this.messageRunner.dishonor();
+                this.game.checkGameState(true);
+            });
+
+            it('should gain ancestral in the fate phase', function () {
+                this.player1.clickCard(this.lionsShadow);
+                this.player1.clickCard(this.messageRunner);
+
+                expect(this.lionsShadow.hasKeyword('ancestral')).toBe(false);
+
+                this.flow.finishConflictPhase();
+                expect(this.lionsShadow.hasKeyword('ancestral')).toBe(true);
+            });
+        });
+
+        describe('The Lions Shadow covert', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['matsu-berserker', 'ikoma-message-runner'],
+                        hand: ['the-lion-s-shadow']
+                    },
+                    player2: {
+                        inPlay: ['hantei-sotorii', 'kakita-yoshi']
+                    }
+                });
+
+                this.berserker = this.player1.findCardByName('matsu-berserker');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.lionsShadow = this.player1.findCardByName('the-lion-s-shadow');
+
+                this.sotorii = this.player2.findCardByName('hantei-sotorii');
+                this.yoshi = this.player2.findCardByName('kakita-yoshi');
+                this.shamefulDisplay = this.player2.findCardByName('shameful-display', 'province 1');
+
+                this.player1.playAttachment(this.lionsShadow, this.messageRunner);
+            });
+
+            it('should have covert when attacking alone', function () {
+                this.noMoreActions();
+                this.player1.clickRing('air');
+                this.player1.clickCard(this.shamefulDisplay);
+                this.player1.clickCard(this.messageRunner);
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player1).toHavePrompt('Choose covert target for Ikoma Message Runner');
+                this.player1.clickCard(this.sotorii);
+                expect(this.sotorii.covert).toBe(true);
+                expect(this.player2).toHavePrompt('Choose Defenders');
+                this.player2.clickCard(this.sotorii);
+                this.player2.clickCard(this.yoshi);
+                this.player2.clickPrompt('Done');
+                expect(this.sotorii.isParticipating()).toBe(false);
+                expect(this.yoshi.isParticipating()).toBe(true);
+            });
+
+            it('should not have covert when not attacking alone', function () {
+                this.noMoreActions();
+                this.player1.clickRing('air');
+                this.player1.clickCard(this.shamefulDisplay);
+                this.player1.clickCard(this.berserker);
+                this.player1.clickCard(this.messageRunner);
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player1).not.toHavePrompt('Choose covert target for Ikoma Message Runner');
+                expect(this.player2).toHavePrompt('Choose Defenders');
+                this.player2.clickCard(this.sotorii);
+                this.player2.clickCard(this.yoshi);
+                this.player2.clickPrompt('Done');
+                expect(this.sotorii.isParticipating()).toBe(true);
+                expect(this.yoshi.isParticipating()).toBe(true);
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/ForcedRetirement.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/ForcedRetirement.spec.js
@@ -1,0 +1,70 @@
+describe('Forced Retirement', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-hotaru', 'cautious-scout'],
+                    hand: ['forced-retirement']
+                },
+                player2: {
+                    inPlay: ['bayushi-aramoro']
+                }
+            });
+
+            this.cautiousScout = this.player1.findCardByName('cautious-scout');
+            this.cautiousScout.fate = 2;
+            this.cautiousScout.taint();
+            this.hotaru = this.player1.findCardByName('doji-hotaru');
+            this.hotaru.fate = 2;
+            this.hotaru.dishonor();
+            this.aramoro = this.player2.findCardByName('bayushi-aramoro');
+            this.aramoro.fate = 2;
+            this.aramoro.dishonor();
+
+            this.forcedRetirement = this.player1.findCardByName('forced-retirement');
+        });
+
+        it('can only choose your own characters', function () {
+            this.player1.clickCard(this.forcedRetirement);
+            expect(this.player1).not.toBeAbleToSelect(this.aramoro);
+            expect(this.player1).toBeAbleToSelect(this.hotaru);
+            expect(this.player1).toBeAbleToSelect(this.cautiousScout);
+        });
+
+        it('can only choose characters at home', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.hotaru],
+                defenders: [this.aramoro]
+            });
+            this.player2.pass();
+            this.player1.clickCard(this.forcedRetirement);
+            expect(this.player1).not.toBeAbleToSelect(this.aramoro);
+            expect(this.player1).not.toBeAbleToSelect(this.hotaru);
+            expect(this.player1).toBeAbleToSelect(this.cautiousScout);
+        });
+
+        it('returns the fate from the character', function () {
+            let p1FateBefore = this.player1.fate;
+            this.player1.clickCard(this.forcedRetirement);
+            this.player1.clickCard(this.hotaru);
+            expect(this.player1.fate).toBe(p1FateBefore + 2);
+        });
+
+        it('discards all character status, then discard it', function () {
+            let p1HonorBefore = this.player1.honor;
+            this.player1.clickCard(this.forcedRetirement);
+            this.player1.clickCard(this.hotaru);
+            expect(this.player1.honor).toBe(p1HonorBefore + 1);
+        });
+
+        it('explains what happened in the chat logs', function () {
+            this.player1.clickCard(this.forcedRetirement);
+            this.player1.clickCard(this.hotaru);
+            expect(this.getChatLogs(1)).toContain(
+                'player1 plays Forced Retirement to expiate Doji Hotaru\'s misdeeds by retiring them to the nearest monatery, recovering their 2 fate. Let them contemplate their sins.'
+            );
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/JealousAncestor.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/JealousAncestor.spec.js
@@ -1,0 +1,368 @@
+describe('Jealous Ancestor', function () {
+    integration(function () {
+        describe('Jealous Ancestor as an attachment', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['gifted-tactician', 'seppun-truthseeker', 'keeper-initiate', 'adept-of-shadows'],
+                        hand: ['tactical-ingenuity', 'hurricane-punch', 'prepare-for-war'],
+                        dynastyDiscard: ['ancestral-armory'],
+                        conflictDiscard: ['fine-katana']
+                    },
+                    player2: {
+                        inPlay: ['master-whisperer', 'miya-mystic', 'kitsu-spiritcaller'],
+                        hand: ['backhanded-compliment', 'assassination', 'jealous-ancestor'],
+                        dynastyDiscard: ['esteemed-tea-house']
+                    }
+                });
+
+                this.giftedTactician = this.player1.findCardByName('gifted-tactician');
+                this.truthseeker = this.player1.findCardByName('seppun-truthseeker');
+                this.keeper = this.player1.findCardByName('keeper-initiate');
+                this.ingenuity = this.player1.findCardByName('tactical-ingenuity');
+                this.hurricane = this.player1.findCardByName('hurricane-punch');
+                this.prepareForWar = this.player1.findCardByName('prepare-for-war');
+                this.adeptOfShadows = this.player1.findCardByName('adept-of-shadows');
+                this.ancestralArmory = this.player1.placeCardInProvince('ancestral-armory', 'province 1');
+
+                this.jealousAncestor = this.player2.findCardByName('jealous-ancestor');
+                this.spiritcaller = this.player2.findCardByName('kitsu-spiritcaller');
+                this.mystic = this.player2.findCardByName('miya-mystic');
+                this.whisperer = this.player2.findCardByName('master-whisperer');
+                this.bhc = this.player2.findCardByName('backhanded-compliment');
+                this.assassination = this.player2.findCardByName('assassination');
+                this.teaHouse = this.player2.placeCardInProvince('esteemed-tea-house', 'province 1');
+            });
+
+            it('can be played as a character', function () {
+                this.player1.pass();
+                this.player2.clickCard(this.jealousAncestor);
+                this.player2.clickPrompt('Play this character');
+                this.player2.clickPrompt('0');
+                expect(this.jealousAncestor.location).toBe('play area');
+            });
+
+            it('can be played as an attachment', function () {
+                this.player1.pass();
+
+                this.player2.clickCard(this.jealousAncestor);
+                this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                this.player2.clickCard(this.giftedTactician);
+                expect(this.giftedTactician.attachments.size()).toBe(1);
+            });
+
+            it('should be treated as an attachment in play', function () {
+                this.player1.pass();
+
+                this.player2.clickCard(this.jealousAncestor);
+                this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                this.player2.clickCard(this.giftedTactician);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'political',
+                    attackers: [this.giftedTactician, this.keeper],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.assassination);
+                expect(this.player2).toBeAbleToSelect(this.giftedTactician);
+                expect(this.player2).not.toBeAbleToSelect(this.jealousAncestor);
+
+                this.player2.clickPrompt('Cancel');
+
+                this.player2.clickCard(this.mystic);
+                expect(this.player2).toBeAbleToSelect(this.jealousAncestor);
+            });
+
+            it('should be treated as a character if it goes to the discard pile', function () {
+                this.player1.pass();
+
+                this.player2.clickCard(this.jealousAncestor);
+                this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                this.player2.clickCard(this.giftedTactician);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    type: 'political',
+                    attackers: [this.giftedTactician, this.keeper],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.mystic);
+                this.player2.clickCard(this.jealousAncestor);
+                expect(this.jealousAncestor.location).toBe('conflict discard pile');
+
+                this.player1.pass();
+                this.player2.clickCard(this.spiritcaller);
+                expect(this.player2).toBeAbleToSelect(this.jealousAncestor);
+                this.player2.clickCard(this.jealousAncestor);
+                expect(this.jealousAncestor.location).toBe('play area');
+            });
+
+            it('immune to events', function () {
+                this.player1.pass();
+
+                this.player2.clickCard(this.jealousAncestor);
+                this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                this.player2.clickCard(this.giftedTactician);
+
+                this.player1.clickCard(this.prepareForWar);
+                this.player1.clickCard(this.giftedTactician);
+
+                expect(this.player1).not.toHavePrompt('Choose any amount of attachments');
+                expect(this.giftedTactician.attachments.size()).toBe(1);
+            });
+
+            it('adds Haunted trait to parent', function () {
+                this.player1.pass();
+
+                this.player2.clickCard(this.jealousAncestor);
+                this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                this.player2.clickCard(this.giftedTactician);
+
+                expect(this.giftedTactician.hasTrait('haunted')).toBe(true);
+            });
+
+            describe('when parent is participating', function () {
+                beforeEach(function () {
+                    this.player1.clickCard(this.ingenuity);
+                    this.player1.clickCard(this.giftedTactician);
+
+                    this.player2.clickCard(this.jealousAncestor);
+                    this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                    this.player2.clickCard(this.giftedTactician);
+
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        type: 'military',
+                        attackers: [this.giftedTactician, this.keeper],
+                        defenders: [this.whisperer],
+                        ring: 'earth'
+                    });
+                });
+
+                it('blocks parent player draw effects', function () {
+                    this.noMoreActions();
+                    expect(this.player1).not.toHavePrompt('Any reactions?');
+                    expect(this.player1).not.toBeAbleToSelect(this.giftedTactician);
+                });
+
+                it('blocks parent player deck search', function () {
+                    this.player2.pass();
+
+                    this.player1.clickCard(this.giftedTactician);
+                    expect(this.player1).toHavePrompt('Select a card to reveal');
+                    expect(this.player1).not.toHavePromptButton('Supernatural Storm (4)');
+                    expect(this.player1).toHavePromptButton('Take nothing');
+
+                    this.player1.clickPrompt('Take nothing');
+                    expect(this.getChatLogs(5)).toContain('player1 takes nothing');
+                    expect(this.getChatLogs(5)).toContain('player1 is shuffling their conflict deck');
+                });
+
+                it('blocks parent return cards to hand', function () {
+                    this.player2.pass();
+                    this.player1.clickCard(this.ancestralArmory);
+                    expect(this.player1).not.toHavePrompt('Ancestral Armory');
+                });
+
+                it('blocks parent return characters to hand', function () {
+                    this.player2.pass();
+                    expect(this.adeptOfShadows.location).toBe('play area');
+                    this.player1.clickCard(this.adeptOfShadows);
+                    expect(this.adeptOfShadows.location).toBe('play area');
+                });
+
+                it('does not block draw from opponent events', function () {
+                    let initialHand = this.player1.hand.length;
+                    this.player2.clickCard(this.bhc);
+                    this.player2.clickPrompt('player1');
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 plays Backhanded Compliment to make player1 lose an honor and draw a card'
+                    );
+                    expect(this.player1.hand.length).toBe(initialHand + 1);
+                });
+
+                it('does not block draw from opponent characters', function () {
+                    this.player2.clickCard(this.whisperer);
+                    this.player2.clickPrompt('player1');
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 uses Master Whisperer to make player1 discard 2 cards and draw 3 cards'
+                    );
+                    expect(this.player1.hand.length).toBe(3);
+                });
+
+                it('does not block return to hand from opponent effects', function () {
+                    this.player2.clickCard(this.teaHouse);
+                    this.player2.clickCard(this.ingenuity);
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 uses Esteemed Tea House to return Tactical Ingenuity to player1\'s hand and prevent them from playing copies this phase'
+                    );
+                    expect(this.ingenuity.location).toBe('hand');
+                });
+            });
+
+            describe('when parent is participating but void ring is claimed', function () {
+                beforeEach(function () {
+                    this.game.rings.void.claimRing(this.player1.player);
+
+                    this.player1.clickCard(this.ingenuity);
+                    this.player1.clickCard(this.giftedTactician);
+
+                    this.player2.clickCard(this.jealousAncestor);
+                    this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                    this.player2.clickCard(this.giftedTactician);
+
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        type: 'military',
+                        attackers: [this.giftedTactician],
+                        defenders: [this.whisperer],
+                        ring: 'earth'
+                    });
+                });
+
+                it('does not block parent player draw effects', function () {
+                    this.noMoreActions();
+                    expect(this.player1).toHavePrompt('Any reactions?');
+                    expect(this.player1).toBeAbleToSelect(this.giftedTactician);
+                });
+
+                it('does not block parent player deck search', function () {
+                    this.player2.pass();
+
+                    this.player1.clickCard(this.giftedTactician);
+                    expect(this.player1).toHavePrompt('Select a card to reveal');
+                    expect(this.player1).toHavePromptButton('Supernatural Storm (4)');
+                    expect(this.player1).toHavePromptButton('Take nothing');
+
+                    this.player1.clickPrompt('Supernatural Storm (4)');
+                    expect(this.getChatLogs(5)).toContain('player1 takes Supernatural Storm');
+                    expect(this.getChatLogs(5)).toContain('player1 is shuffling their conflict deck');
+                });
+
+                it('does not block parent return cards to hand', function () {
+                    this.player2.pass();
+                    this.player1.clickCard(this.ancestralArmory);
+                    expect(this.player1).toHavePrompt('Ancestral Armory');
+                });
+
+                it('does not block parent return characters to hand', function () {
+                    this.player2.pass();
+                    expect(this.adeptOfShadows.location).toBe('play area');
+                    this.player1.clickCard(this.adeptOfShadows);
+                    expect(this.adeptOfShadows.location).toBe('hand');
+                });
+
+                it('does not block draw from opponent events', function () {
+                    let initialHand = this.player1.hand.length;
+                    this.player2.clickCard(this.bhc);
+                    this.player2.clickPrompt('player1');
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 plays Backhanded Compliment to make player1 lose an honor and draw a card'
+                    );
+                    expect(this.player1.hand.length).toBe(initialHand + 1);
+                });
+
+                it('does not block draw from opponent characters', function () {
+                    this.player2.clickCard(this.whisperer);
+                    this.player2.clickPrompt('player1');
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 uses Master Whisperer to make player1 discard 2 cards and draw 3 cards'
+                    );
+                    expect(this.player1.hand.length).toBe(3);
+                });
+
+                it('does not block return to hand from opponent effects', function () {
+                    this.player2.clickCard(this.teaHouse);
+                    this.player2.clickCard(this.ingenuity);
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 uses Esteemed Tea House to return Tactical Ingenuity to player1\'s hand and prevent them from playing copies this phase'
+                    );
+                    expect(this.ingenuity.location).toBe('hand');
+                });
+            });
+
+            describe('when parent is not participating', function () {
+                beforeEach(function () {
+                    this.player1.clickCard(this.ingenuity);
+                    this.player1.clickCard(this.giftedTactician);
+
+                    this.player2.clickCard(this.jealousAncestor);
+                    this.player2.clickPrompt('Play Jealous Ancestor as an attachment');
+                    this.player2.clickCard(this.keeper);
+
+                    this.noMoreActions();
+                    this.initiateConflict({
+                        type: 'military',
+                        attackers: [this.giftedTactician],
+                        defenders: [this.whisperer],
+                        ring: 'earth'
+                    });
+                });
+
+                it('does not block parent player draw effects', function () {
+                    this.noMoreActions();
+                    expect(this.player1).toHavePrompt('Any reactions?');
+                    expect(this.player1).toBeAbleToSelect(this.giftedTactician);
+                });
+
+                it('does not block parent player deck search', function () {
+                    this.player2.pass();
+
+                    this.player1.clickCard(this.giftedTactician);
+                    expect(this.player1).toHavePrompt('Select a card to reveal');
+                    expect(this.player1).toHavePromptButton('Supernatural Storm (4)');
+                    expect(this.player1).toHavePromptButton('Take nothing');
+
+                    this.player1.clickPrompt('Supernatural Storm (4)');
+                    expect(this.getChatLogs(5)).toContain('player1 takes Supernatural Storm');
+                    expect(this.getChatLogs(5)).toContain('player1 is shuffling their conflict deck');
+                });
+
+                it('does not block parent return cards to hand', function () {
+                    this.player2.pass();
+                    this.player1.clickCard(this.ancestralArmory);
+                    expect(this.player1).toHavePrompt('Ancestral Armory');
+                });
+
+                it('does not block parent return characters to hand', function () {
+                    this.player2.pass();
+                    expect(this.adeptOfShadows.location).toBe('play area');
+                    this.player1.clickCard(this.adeptOfShadows);
+                    expect(this.adeptOfShadows.location).toBe('hand');
+                });
+
+                it('does not block draw from opponent events', function () {
+                    let initialHand = this.player1.hand.length;
+                    this.player2.clickCard(this.bhc);
+                    this.player2.clickPrompt('player1');
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 plays Backhanded Compliment to make player1 lose an honor and draw a card'
+                    );
+                    expect(this.player1.hand.length).toBe(initialHand + 1);
+                });
+
+                it('does not block draw from opponent characters', function () {
+                    this.player2.clickCard(this.whisperer);
+                    this.player2.clickPrompt('player1');
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 uses Master Whisperer to make player1 discard 2 cards and draw 3 cards'
+                    );
+                    expect(this.player1.hand.length).toBe(3);
+                });
+
+                it('does not block return to hand from opponent effects', function () {
+                    this.player2.clickCard(this.teaHouse);
+                    this.player2.clickCard(this.ingenuity);
+                    expect(this.getChatLogs(5)).toContain(
+                        'player2 uses Esteemed Tea House to return Tactical Ingenuity to player1\'s hand and prevent them from playing copies this phase'
+                    );
+                    expect(this.ingenuity.location).toBe('hand');
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/Kuro.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/Kuro.spec.js
@@ -1,0 +1,152 @@
+describe('Kuro', function () {
+    integration(function () {
+        describe('attachment limitation', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['kuro'],
+                        hand: ['fine-katana', 'above-question', 'adorned-barcha']
+                    }
+                });
+
+                this.kuro = this.player1.findCardByName('kuro');
+                this.katana = this.player1.findCardByName('fine-katana');
+                this.aq = this.player1.findCardByName('above-question');
+                this.barcha = this.player1.findCardByName('adorned-barcha');
+            });
+
+            it('should not allow for printed cost 0 to be attached', function () {
+                this.player1.clickCard(this.katana);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('should allow for printed cost 1 to be attached', function () {
+                this.player1.clickCard(this.aq);
+                expect(this.player1).toHavePrompt('Choose a card');
+                expect(this.player1).toBeAbleToSelect(this.kuro);
+                this.player1.clickCard(this.kuro);
+                expect(this.aq.parent).toBe(this.kuro);
+            });
+
+            it('should allow for printed cost 1 or higher to be attached', function () {
+                this.player1.clickCard(this.barcha);
+                expect(this.player1).toHavePrompt('Choose a card');
+                expect(this.player1).toBeAbleToSelect(this.kuro);
+                this.player1.clickCard(this.kuro);
+                expect(this.barcha.parent).toBe(this.kuro);
+            });
+        });
+
+        describe('action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['kuro', 'ikoma-prodigy']
+                    },
+                    player2: {
+                        conflictDiscard: ['fine-katana', 'above-question', 'adorned-barcha', 'total-warfare']
+                    }
+                });
+
+                this.kuro = this.player1.findCardByName('kuro');
+                this.ikomaProdigy = this.player1.findCardByName('ikoma-prodigy');
+
+                this.katana = this.player2.findCardByName('fine-katana');
+                this.aq = this.player2.findCardByName('above-question');
+                this.barcha = this.player2.findCardByName('adorned-barcha');
+                this.totalWarfare = this.player2.findCardByName('total-warfare');
+            });
+
+            it('should not work outside a conflict', function () {
+                this.player1.clickCard(this.kuro);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('should allow to target attachments with printed cost 1 or higher in the opponent discard pile', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.kuro],
+                    defenders: [],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.kuro);
+                expect(this.player1).toHavePrompt('Choose an attachment');
+                expect(this.player1).not.toBeAbleToSelect(this.katana);
+                expect(this.player1).not.toBeAbleToSelect(this.totalWarfare);
+                expect(this.player1).toBeAbleToSelect(this.aq);
+                expect(this.player1).toBeAbleToSelect(this.barcha);
+            });
+
+            it('when choosing an attachment, it should play it on Kuro, reduced by 1 fate', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.kuro],
+                    defenders: [],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+
+                const initialFate = this.player1.fate;
+                this.player1.clickCard(this.kuro);
+                this.player1.clickCard(this.aq);
+                expect(this.aq.parent).toBe(this.kuro);
+                expect(this.player1.fate).toBe(initialFate - 0); // 1 cost attachment reduced by 1
+            });
+
+            it('when choosing an attachment, it should play it on Kuro, reduced by 1 fate, while still paying fate if printed cost higher than 2', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.kuro],
+                    defenders: [],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+
+                const initialFate = this.player1.fate;
+                this.player1.clickCard(this.kuro);
+                this.player1.clickCard(this.barcha);
+                expect(this.barcha.parent).toBe(this.kuro);
+                expect(this.player1.fate).toBe(initialFate - 1); // 2 cost attachment reduced by 1
+            });
+
+            it('after attaching, if Kuro was at home should move to the conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.ikomaProdigy],
+                    defenders: [],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.kuro);
+                this.player1.clickCard(this.aq);
+                expect(this.kuro.isParticipating()).toBe(true);
+                expect(this.getChatLogs(5)).toContain('player1 uses Kuro to seek the lost treasure \'Above Question\'. Kuro swoops into the conflict');
+            });
+
+            it('after attaching, if Kuro was in the conflict, Kuro should move home', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.kuro],
+                    defenders: [],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.kuro);
+                this.player1.clickCard(this.aq);
+                expect(this.kuro.isParticipating()).toBe(false);
+                expect(this.getChatLogs(5)).toContain('player1 uses Kuro to seek the lost treasure \'Above Question\'. Kuro returns home with their treasure');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/MangroveSafehouse.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/MangroveSafehouse.spec.js
@@ -1,0 +1,198 @@
+describe('Mangrove Safehouse', function () {
+    integration(function () {
+        describe('Mangrove Safehouse\'s ability', function () {
+            describe('Outside of a conflict', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            dynastyDiscard: ['mangrove-safehouse'],
+                            inPlay: ['adept-of-the-waves', 'kudaka']
+                        },
+                        player2: {
+                            inPlay: ['bayushi-manipulator', 'yuta']
+                        }
+                    });
+                    this.mangroveSafehouse = this.player1.placeCardInProvince(
+                        'mangrove-safehouse',
+                        'province 2'
+                    );
+                });
+
+                it('should not be triggered outside of a conflict', function () {
+                    this.player1.clickCard(this.mangroveSafehouse);
+                    expect(this.player1).toHavePrompt('Initiate an action');
+                });
+            });
+
+            describe('While defending', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            dynastyDiscard: ['mangrove-safehouse'],
+                            inPlay: ['adept-of-the-waves', 'kudaka']
+                        },
+                        player2: {
+                            inPlay: ['bayushi-manipulator', 'yuta']
+                        }
+                    });
+
+                    this.adeptOfTheWaves =
+                        this.player1.findCardByName('adept-of-the-waves');
+                    this.kudaka = this.player1.findCardByName('kudaka');
+                    this.mangroveSafehouse = this.player1.placeCardInProvince(
+                        'mangrove-safehouse',
+                        'province 2'
+                    );
+
+                    this.bayushiManipulator = this.player2.findCardByName(
+                        'bayushi-manipulator'
+                    );
+                    this.yuta = this.player2.findCardByName('yuta');
+
+                    this.noMoreActions();
+                    this.player1.passConflict();
+                    this.noMoreActions();
+                });
+
+                it('should not trigger on political defenses', function () {
+                    this.initiateConflict({
+                        type: 'political',
+                        attackers: [this.bayushiManipulator, this.yuta],
+                        defenders: [this.adeptOfTheWaves, this.kudaka]
+                    });
+                    expect(this.player1).toHavePrompt('Conflict Action Window');
+                    this.player1.clickCard(this.mangroveSafehouse);
+                    expect(this.player1).toHavePrompt('Conflict Action Window');
+                });
+
+                it('should not trigger on military defenses', function () {
+                    this.initiateConflict({
+                        type: 'military',
+                        attackers: [this.bayushiManipulator, this.yuta],
+                        defenders: [this.adeptOfTheWaves, this.kudaka]
+                    });
+                    expect(this.player1).toHavePrompt('Conflict Action Window');
+                    this.player1.clickCard(this.mangroveSafehouse);
+                    expect(this.player1).toHavePrompt('Conflict Action Window');
+                });
+            });
+
+            ['political', 'military'].map((conflictType) => {
+                describe(`While attacking ${conflictType}`, function () {
+                    beforeEach(function () {
+                        this.setupTest({
+                            phase: 'conflict',
+                            player1: {
+                                dynastyDiscard: ['mangrove-safehouse'],
+                                inPlay: [
+                                    'adept-of-the-waves',
+                                    'kudaka',
+                                    'solemn-scholar'
+                                ]
+                            },
+                            player2: {
+                                inPlay: [
+                                    'bayushi-manipulator',
+                                    'yuta',
+                                    'keeper-initiate'
+                                ]
+                            }
+                        });
+
+                        this.adeptOfTheWaves =
+                            this.player1.findCardByName('adept-of-the-waves');
+                        this.kudaka = this.player1.findCardByName('kudaka');
+                        this.solemnScholar =
+                            this.player1.findCardByName('solemn-scholar');
+                        this.mangroveSafehouse =
+                            this.player1.placeCardInProvince(
+                                'mangrove-safehouse',
+                                'province 2'
+                            );
+
+                        this.bayushiManipulator = this.player2.findCardByName(
+                            'bayushi-manipulator'
+                        );
+                        this.yuta = this.player2.findCardByName('yuta');
+                        this.keeperInitiate =
+                            this.player2.findCardByName('keeper-initiate');
+
+                        this.p1FateBefore = this.player1.fate;
+                        this.p2FateBefore = this.player2.fate;
+                        this.noMoreActions();
+                        this.initiateConflict({
+                            type: conflictType,
+                            attackers: [this.adeptOfTheWaves, this.kudaka],
+                            defenders: [this.bayushiManipulator, this.yuta]
+                        });
+                        this.player2.clickPrompt('Pass');
+
+                        this.player1.clickCard(this.mangroveSafehouse);
+                    });
+
+                    it('should prompt to select a character', function () {
+                        expect(this.player1).toHavePrompt('Choose a character');
+                    });
+
+                    it('should not allow target a unit you do not control', function () {
+                        expect(this.player1).not.toBeAbleToSelect(
+                            this.bayushiManipulator
+                        );
+                        expect(this.player1).not.toBeAbleToSelect(this.yuta);
+                        expect(this.player1).not.toBeAbleToSelect(
+                            this.keeperInitiate
+                        );
+                    });
+
+                    it('should not allow target a unit at home', function () {
+                        expect(this.player1).not.toBeAbleToSelect(
+                            this.solemnScholar
+                        );
+                    });
+
+                    describe('if a non-Mantis character is selected', function () {
+                        beforeEach(function () {
+                            this.player1.clickCard(this.adeptOfTheWaves);
+                        });
+
+                        it('moves the target home and steals no fate', function () {
+                            expect(this.adeptOfTheWaves.inConflict).toBe(false);
+                            expect(
+                                this.game.currentConflict.attackers
+                            ).not.toContain(this.adeptOfTheWaves);
+                            expect(this.player1.fate).toBe(this.p1FateBefore);
+                            expect(this.player2.fate).toBe(this.p2FateBefore);
+                            expect(this.getChatLogs(3)).toContain(
+                                'player1 uses Mangrove Safehouse to move Adept of the Waves home'
+                            );
+                        });
+                    });
+
+                    describe('if a Mantis character is selected', function () {
+                        beforeEach(function () {
+                            this.player1.clickCard(this.kudaka);
+                        });
+
+                        it('moves the target home and steals 1 fate', function () {
+                            expect(this.kudaka.inConflict).toBe(false);
+                            expect(
+                                this.game.currentConflict.attackers
+                            ).not.toContain(this.kudaka);
+                            expect(this.player1.fate).toBe(
+                                this.p1FateBefore + 1
+                            );
+                            expect(this.player2.fate).toBe(
+                                this.p2FateBefore - 1
+                            );
+                            expect(this.getChatLogs(3)).toContain(
+                                'player1 uses Mangrove Safehouse to move Kudaka home and steal 1 fate'
+                            );
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/MantisRaider.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/MantisRaider.spec.js
@@ -1,0 +1,101 @@
+describe('Mantis Raider', function () {
+    integration(function () {
+        describe('unnoposed fate steal', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['mantis-raider']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar'],
+                        fate: 2
+                    }
+                });
+
+                this.mantisRaider =
+                    this.player1.findCardByName('mantis-raider');
+                this.solemScholar =
+                    this.player2.findCardByName('solemn-scholar');
+            });
+
+            it('does not trigger outside a conflict', function () {
+                this.player1.clickCard(this.mantisRaider);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('does not trigger when attacking opposed', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.mantisRaider],
+                    defenders: [this.solemScholar]
+                });
+                expect(this.player1).not.toBeAbleToSelect(this.mantisRaider);
+                expect(this.player1).toHavePrompt(
+                    'Waiting for opponent to take an action or pass'
+                );
+            });
+
+            it('take fate from the opponent when attacking unopposed', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.mantisRaider],
+                    defenders: []
+                });
+
+                let raiderFateBefore = this.mantisRaider.fate;
+                let opponentFateBefore = this.player2.fate;
+                this.player1.clickCard(this.mantisRaider);
+                expect(this.mantisRaider.fate).toBe(raiderFateBefore + 1);
+                expect(this.player2.fate).toBe(opponentFateBefore - 1);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Mantis Raider to take a fate from player2 and place it on Mantis Raider.'
+                );
+            });
+        });
+
+        describe('skill pump', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['mantis-raider']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar']
+                    }
+                });
+
+                this.mantisRaider =
+                    this.player1.findCardByName('mantis-raider');
+                this.mantisRaider.fate = 2;
+                this.solemScholar =
+                    this.player2.findCardByName('solemn-scholar');
+            });
+
+            it('gains skill bonuses by paying fate', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.mantisRaider],
+                    defenders: [this.solemScholar]
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.mantisRaider);
+                expect(this.mantisRaider.militarySkill).toBe(3);
+                expect(this.mantisRaider.fate).toBe(1);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Mantis Raider, removing 1 fate from Mantis Raider to give himself +1military'
+                );
+
+                this.player2.pass();
+                this.player1.clickCard(this.mantisRaider);
+                expect(this.mantisRaider.fate).toBe(0);
+                expect(this.mantisRaider.militarySkill).toBe(4);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Mantis Raider, removing 1 fate from Mantis Raider to give himself +1military'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/MarvelousBeings.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/MarvelousBeings.spec.js
@@ -1,0 +1,76 @@
+describe('Marvelous Beings', function () {
+    integration(function () {
+        describe('action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['wild-stallion', 'guardian-kami', 'akodo-toturi', 'ikoma-prodigy'],
+                        hand: ['marvelous-beings']
+                    }
+                });
+
+                this.wildStallion = this.player1.findCardByName('wild-stallion');
+                this.guardianKami = this.player1.findCardByName('guardian-kami');
+                this.toturi = this.player1.findCardByName('akodo-toturi');
+                this.prodigy = this.player1.findCardByName('ikoma-prodigy');
+
+                this.marvelousBeings = this.player1.findCardByName('marvelous-beings');
+            });
+
+            it('should not trigger outside a conflict', function () {
+                this.player1.clickCard(this.marvelousBeings);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('should not trigger in a military a conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.prodigy],
+                    defenders: [],
+                    ring: 'air',
+                    type: 'military'
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.marvelousBeings);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should trigger in a political conflict and allow to target creature and spirit traits', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.prodigy],
+                    defenders: [],
+                    ring: 'air',
+                    type: 'political'
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.marvelousBeings);
+                expect(this.player1).toHavePrompt('Select card to move to the conflict');
+                expect(this.player1).toBeAbleToSelect(this.wildStallion);
+                expect(this.player1).toBeAbleToSelect(this.guardianKami);
+                expect(this.player1).not.toBeAbleToSelect(this.toturi);
+                expect(this.player1).not.toBeAbleToSelect(this.prodigy);
+            });
+
+            it('should move the chosen card to the conflict and add printed cost to the total, not modify its skill', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.prodigy],
+                    defenders: [],
+                    ring: 'air',
+                    type: 'political'
+                });
+                this.player2.pass();
+                this.player1.clickCard(this.marvelousBeings);
+                this.player1.clickCard(this.guardianKami);
+
+                expect(this.guardianKami.isParticipating()).toBe(true);
+                expect(this.guardianKami.getPoliticalSkill()).toBe(1);
+
+                expect(this.getChatLogs(5)).toContain('player1 plays Marvelous Beings, moving Guardian Kami into the conflict to entrance the court, giving their side an extra 2political this conflict');
+                expect(this.getChatLogs(5)).toContain('Political Air conflict - Attacker: 5 Defender: 0'); //2 printed cost + 2 prodigy + 1 kami itself
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/MischievousTanuki.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/MischievousTanuki.spec.js
@@ -1,0 +1,170 @@
+describe('Mischievous Tanuki', function () {
+    integration(function () {
+        describe('Tanuki ability - during conflict phase', function () {
+            it('does not work during dynasty phase', function () {
+                this.setupTest({
+                    phase: 'dynasty',
+                    player1: {
+                        inPlay: ['mischievous-tanuki'],
+                        hand: []
+                    },
+                    player2: {
+                        inPlay: []
+                    }
+                });
+
+                this.tanuki = this.player1.findCardByName('mischievous-tanuki');
+
+                expect(this.player1).toHavePrompt('Click pass when done');
+                this.player1.clickCard(this.tanuki);
+                expect(this.player1).toHavePrompt('Click pass when done');
+            });
+
+            it('does not work during draw phase', function () {
+                this.setupTest({
+                    phase: 'draw',
+                    player1: {
+                        inPlay: ['mischievous-tanuki'],
+                        hand: []
+                    },
+                    player2: {
+                        inPlay: []
+                    }
+                });
+                this.tanuki = this.player1.findCardByName('mischievous-tanuki');
+
+                this.player1.clickPrompt('1');
+                this.player2.clickPrompt('1');
+
+                expect(this.player1).toHavePrompt('Initiate an action');
+                this.player1.clickCard(this.tanuki);
+                expect(this.player1).toHavePrompt('Initiate an action');
+            });
+
+            it('does not work during fate phase', function () {
+                this.setupTest({
+                    phase: 'fate',
+                    player1: {
+                        inPlay: ['mischievous-tanuki'],
+                        hand: []
+                    },
+                    player2: {
+                        inPlay: []
+                    }
+                });
+                this.tanuki = this.player1.findCardByName('mischievous-tanuki');
+
+                expect(this.player1).toHavePrompt('Initiate an action');
+                this.player1.clickCard(this.tanuki);
+                expect(this.player1).toHavePrompt('Initiate an action');
+            });
+        });
+
+        describe('Tanuki ability - during conflict phase', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['mischievous-tanuki', 'bayushi-manipulator'],
+                        hand: []
+                    },
+                    player2: {
+                        inPlay: []
+                    }
+                });
+
+                this.player1.player.showBid = 5;
+                this.player2.player.showBid = 5;
+
+                this.tanuki = this.player1.findCardByName('mischievous-tanuki');
+            });
+
+            it('should prompt each player to choose a bid and not transfer honor and should not proc dial revealed reactions', function () {
+                let p1Honor = this.player1.honor;
+                let p2Honor = this.player2.honor;
+                this.player1.clickCard(this.tanuki);
+                expect(this.player1).toHavePrompt('Choose your bid');
+                expect(this.player2).toHavePrompt('Choose your bid');
+
+                expect(this.player1).toHavePromptButton('1');
+                expect(this.player1).toHavePromptButton('2');
+                expect(this.player1).toHavePromptButton('3');
+                expect(this.player1).toHavePromptButton('4');
+                expect(this.player1).toHavePromptButton('5');
+
+                expect(this.player2).toHavePromptButton('1');
+                expect(this.player2).toHavePromptButton('2');
+                expect(this.player2).toHavePromptButton('3');
+                expect(this.player2).toHavePromptButton('4');
+                expect(this.player2).toHavePromptButton('5');
+
+                this.player1.clickPrompt('3');
+
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 has chosen a bid.'
+                );
+                expect(this.player1.player.showBid).toBe(5);
+
+                this.player2.clickPrompt('1');
+
+                expect(this.getChatLogs(5)).toContain(
+                    'player2 has chosen a bid.'
+                );
+                expect(this.getChatLogs(10)).toContain(
+                    'player1 reveals a bid of 3'
+                );
+                expect(this.getChatLogs(10)).toContain(
+                    'player2 reveals a bid of 1'
+                );
+                expect(this.player1.player.showBid).toBe(3);
+                expect(this.player2.player.showBid).toBe(1);
+
+                expect(this.player1.honor).toBe(p1Honor);
+                expect(this.player2.honor).toBe(p2Honor);
+            });
+
+            it('both same parity', function () {
+                let p1Fate = this.player1.fate;
+                let p2Fate = this.player2.fate;
+
+                this.player1.clickCard(this.tanuki);
+                this.player1.clickPrompt('3');
+                this.player2.clickPrompt('1');
+
+                expect(this.player2).toHavePrompt('Action Window');
+
+                expect(this.player1.fate).toBe(p1Fate + 2);
+                expect(this.player2.fate).toBe(p2Fate - 2);
+                expect(this.getChatLogs(10)).toContain(
+                    'player1 takes 2 fate from player2'
+                );
+            });
+
+            it('different parity', function () {
+                let p1Fate = this.player1.fate;
+                let p2Fate = this.player2.fate;
+                let p1Honor = this.player1.honor;
+                let p2Honor = this.player2.honor;
+                let p1cards = this.player1.hand.length;
+                let p2cards = this.player2.hand.length;
+
+                this.player1.clickCard(this.tanuki);
+                this.player1.clickPrompt('3');
+                this.player2.clickPrompt('2');
+
+                expect(this.player1.fate).toBe(p1Fate);
+                expect(this.player2.fate).toBe(p2Fate);
+
+                expect(this.player1.honor).toBe(p1Honor);
+                expect(this.player2.honor).toBe(p2Honor + 2);
+
+                expect(this.player1.hand.length).toBe(p1cards + 2);
+                expect(this.player2.hand.length).toBe(p2cards);
+
+                expect(this.getChatLogs(10)).toContain(
+                    'player1 draws 2 cards and player2 gains 2 honor'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/OtterFisherman.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/OtterFisherman.spec.js
@@ -1,0 +1,191 @@
+describe('Otter Fisherman', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['otter-fisherman', 'isawa-tadaka']
+                },
+                player2: {
+                    inPlay: ['solemn-scholar', 'kitsu-motso']
+                }
+            });
+
+            this.otterFisherman = this.player1.findCardByName('otter-fisherman');
+            this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+
+            this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+            this.kitsuMotso = this.player2.findCardByName('kitsu-motso');
+            this.player1.player.imperialFavor = 'political';
+        });
+
+        it('should not be able to trigger in a non-water conflict', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.otterFisherman],
+                defenders: [],
+                type: 'political',
+                ring: 'earth'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('Don\'t resolve');
+
+            expect(this.player1).not.toHavePrompt('Triggered Abilities');
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+
+        it('should not be able to trigger when the opponent claims the ring', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.otterFisherman],
+                defenders: [this.kitsuMotso],
+                type: 'political',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+
+            expect(this.player1).not.toHavePrompt('Triggered Abilities');
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+
+        it('should be able to trigger in a political water conflict', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.otterFisherman],
+                defenders: [],
+                type: 'political',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('Don\'t resolve');
+
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.otterFisherman);
+        });
+
+        it('should be able to trigger in a military water conflict', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                type: 'military',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('No');
+            this.player1.clickPrompt('Don\'t resolve');
+
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.otterFisherman);
+        });
+
+        it('should be able to trigger in a water conflict where fisherman is not participating', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                type: 'political',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('No');
+            this.player1.clickPrompt('Don\'t resolve');
+
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.otterFisherman);
+        });
+
+        it('should prompt player2 to choose one of the options', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.otterFisherman],
+                defenders: [],
+                type: 'political',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('Don\'t resolve');
+
+            this.player1.clickCard(this.otterFisherman);
+            expect(this.player2).toHavePrompt('Choose an option for your opponent');
+            expect(this.player2.currentButtons).toContain('Opponent gains 1 fate');
+            expect(this.player2.currentButtons).toContain('Opponent gains 1 honor');
+            expect(this.player2.currentButtons).toContain('Opponent draws 1 card');
+        });
+
+        it('should give player1 1 honor if chosen', function() {
+            let initialHonor = this.player1.honor;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.otterFisherman],
+                defenders: [],
+                type: 'political',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('Don\'t resolve');
+
+            this.player1.clickCard(this.otterFisherman);
+            this.player2.clickPrompt('Opponent gains 1 honor');
+
+            expect(this.player1.honor).toBe(initialHonor + 1);
+            expect(this.getChatLogs(3)).toContain('player1 uses Otter Fisherman to gain 1 honor');
+        });
+
+        it('should give player1 1 fate if chosen', function() {
+            let initialFate = this.player1.fate;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.otterFisherman],
+                defenders: [],
+                type: 'political',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('Don\'t resolve');
+
+            this.player1.clickCard(this.otterFisherman);
+            this.player2.clickPrompt('Opponent gains 1 fate');
+
+            expect(this.player1.fate).toBe(initialFate + 1);
+            expect(this.getChatLogs(3)).toContain('player1 uses Otter Fisherman to gain 1 fate');
+        });
+
+        it('should give player1 1 card if chosen', function() {
+            let initialHandSize = this.player1.hand.length;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.otterFisherman],
+                defenders: [],
+                type: 'political',
+                ring: 'water'
+            });
+
+            this.player2.pass();
+            this.player1.pass();
+            this.player1.clickPrompt('Don\'t resolve');
+
+            this.player1.clickCard(this.otterFisherman);
+            this.player2.clickPrompt('Opponent draws 1 card');
+
+            expect(this.player1.hand.length).toBe(initialHandSize + 1);
+            expect(this.getChatLogs(3)).toContain('player1 uses Otter Fisherman to draw 1 card');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/ToConnectThePeople.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/ToConnectThePeople.spec.js
@@ -1,0 +1,94 @@
+describe('To Connect the People', function () {
+    integration(function () {
+        describe('action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['ikoma-prodigy', 'forthright-ide'],
+                        hand: ['to-connect-the-people'],
+                        dynastyDiscard: ['border-rider'],
+                        conflictDiscard: ['shinjo-ambusher']
+                    },
+                    player2: {
+                        dynastyDiscard: ['akodo-kaede', 'akodo-makoto', 'akodo-motivator', 'ashigaru-levy'],
+                        conflictDiscard: ['shiksha-scout', 'ageless-crone', 'ikoma-anakazu', 'renowned-singer']
+                    }
+                });
+                this.toConnectThePeople = this.player1.findCardByName('to-connect-the-people');
+
+                this.ikomaProdigy = this.player1.findCardByName('ikoma-prodigy');
+                this.forthrightIde = this.player1.findCardByName('forthright-ide');
+
+                this.dynastyDiscardBorderRider = this.player1.findCardByName('border-rider');
+                this.conflictDiscardAmbusher = this.player1.findCardByName('shinjo-ambusher');
+
+                this.opponentDynastyDiscardAshigaruLevy = this.player2.findCardByName('ashigaru-levy');
+                this.opponentDynastyDiscardAkodoKaede = this.player2.findCardByName('akodo-kaede');
+                this.opponentDynastyDiscardAkodoMakoto = this.player2.findCardByName('akodo-makoto');
+                this.opponentDynastyDiscardAkodoMotivator = this.player2.findCardByName('akodo-motivator');
+
+                this.opponentConflictDiscardShikshaScout = this.player2.findCardByName('shiksha-scout');
+                this.opponentConflictDiscardAgelessCrone = this.player2.findCardByName('ageless-crone');
+                this.opponentConflictDiscardIkomaAnakazu = this.player2.findCardByName('ikoma-anakazu');
+                this.opponentConflictDiscardRenownedSinger = this.player2.findCardByName('renowned-singer');
+            });
+
+            it('should not trigger during a conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.ikomaProdigy],
+                    defenders: [],
+                    ring: 'air',
+                    type: 'political'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.toConnectThePeople);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('discards a few cards from the opponents dynasty deck', function () {
+                let initialDiscardPile = this.player2.player.dynastyDiscardPile.size();
+
+                this.player1.clickCard(this.toConnectThePeople);
+                expect(this.player2.player.dynastyDiscardPile.size()).toBe(initialDiscardPile + 3);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 plays To Connect the People to discard Adept of the Waves, Adept of the Waves and Adept of the Waves'
+                );
+            });
+
+            it('should allow you to purchase any character from your opponent discard piles that has glory equal or lower than a merchant you control', function () {
+                this.player1.clickCard(this.toConnectThePeople);
+
+                expect(this.player1).toHavePrompt('Choose a character');
+
+                //opponent cards in discard pile with 1 or less glory (from Forthright Ide 1 glory)
+                expect(this.player1).toBeAbleToSelect(this.opponentDynastyDiscardAshigaruLevy);
+                expect(this.player1).toBeAbleToSelect(this.opponentConflictDiscardShikshaScout);
+                expect(this.player1).toBeAbleToSelect(this.opponentConflictDiscardAgelessCrone);
+                expect(this.player1).toBeAbleToSelect(this.opponentDynastyDiscardAkodoMotivator);
+
+                //opponent card and glory not too high, but unique character
+                expect(this.player1).not.toBeAbleToSelect(this.opponentDynastyDiscardAkodoMakoto);
+
+                //opponent cards in discard pile with 2 or more glory
+                expect(this.player1).not.toBeAbleToSelect(this.opponentConflictDiscardIkomaAnakazu);
+                expect(this.player1).not.toBeAbleToSelect(this.opponentDynastyDiscardAkodoKaede);
+                expect(this.player1).not.toBeAbleToSelect(this.opponentConflictDiscardRenownedSinger);
+
+                //own discard pile cards
+                expect(this.player1).not.toBeAbleToSelect(this.dynastyDiscardBorderRider);
+                expect(this.player1).not.toBeAbleToSelect(this.conflictDiscardAmbusher);
+
+                const initialPLayerFate = this.player1.fate;
+                expect(this.player1).toHavePrompt('Choose a character');
+                this.player1.clickCard(this.opponentDynastyDiscardAkodoMotivator);
+                this.player1.clickPrompt('1');
+
+                expect(this.player1.fate).toBe(initialPLayerFate - 5); // 4 fate base + 1 extra fate placed
+                expect(this.opponentDynastyDiscardAkodoMotivator.location).toBe('play area');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/ToGovernTheLand.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/ToGovernTheLand.spec.js
@@ -1,0 +1,117 @@
+describe('To Govern The Land', function () {
+    integration(function () {
+        describe('action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['akodo-toturi', 'hantei-daisetsu', 'ikoma-prodigy'],
+                        hand: ['to-govern-the-land']
+                    },
+                    player2: {
+                        inPlay: ['doji-whisperer', 'daidoji-uji', 'kitsuki-shomon', 'solemn-scholar'],
+                        hand: ['to-govern-the-land']
+                    }
+                });
+
+                this.toturi = this.player1.findCardByName('akodo-toturi');
+                this.daisetsu = this.player1.findCardByName('hantei-daisetsu');
+                this.prodigy = this.player1.findCardByName('ikoma-prodigy');
+
+                this.dojiWhisperer = this.player2.findCardByName('doji-whisperer');
+                this.uji = this.player2.findCardByName('daidoji-uji');
+                this.shomon = this.player2.findCardByName('kitsuki-shomon');
+                this.solemn = this.player2.findCardByName('solemn-scholar');
+
+                this.toGovernPlayer1 = this.player1.findCardByName('to-govern-the-land');
+                this.toGovernPlayer2 = this.player2.findCardByName('to-govern-the-land');
+            });
+
+            it('during a military conflict, it should not trigger if you dont control a courtier', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.toturi],
+                    defenders: [this.dojiWhisperer, this.shomon],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.toGovernPlayer1);
+
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('during a political conflict, it should not trigger if you dont control a bushi', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.daisetsu, this.prodigy],
+                    defenders: [this.dojiWhisperer, this.shomon, this.uji],
+                    type: 'political'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.toGovernPlayer1);
+
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('during a political conflict, it allow you to target any character with lower military skill than your highest power Bushi', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.toturi, this.daisetsu, this.prodigy],
+                    defenders: [this.dojiWhisperer, this.shomon, this.uji],
+                    type: 'political'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.toGovernPlayer1);
+
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.dojiWhisperer);
+                expect(this.player1).toBeAbleToSelect(this.shomon);
+                expect(this.player1).toBeAbleToSelect(this.prodigy); // your own character
+                expect(this.player1).toBeAbleToSelect(this.daisetsu); // your own character
+                expect(this.player1).not.toBeAbleToSelect(this.toturi); // equal military
+                expect(this.player1).not.toBeAbleToSelect(this.uji); // equal military
+                expect(this.player1).not.toBeAbleToSelect(this.solemn); // at home
+
+                this.player1.clickCard(this.dojiWhisperer);
+
+                expect(this.dojiWhisperer.isParticipating()).toBe(false);
+                expect(this.dojiWhisperer.bowed).toBe(true);
+
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 plays To Govern the Land to send Doji Whisperer home and bow Doji Whisperer'
+                );
+            });
+
+            it('during a military conflict, it allow you to target any character with lower political skill than your highest power Courtier', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.toturi, this.daisetsu, this.prodigy],
+                    defenders: [this.dojiWhisperer, this.shomon, this.uji],
+                    type: 'military'
+                });
+
+                this.player2.clickCard(this.toGovernPlayer2);
+
+                expect(this.player2).toHavePrompt('Choose a character');
+                expect(this.player2).toBeAbleToSelect(this.prodigy);
+                expect(this.player2).toBeAbleToSelect(this.uji); // your own character
+                expect(this.player2).not.toBeAbleToSelect(this.shomon); // equal political
+                expect(this.player2).not.toBeAbleToSelect(this.toturi); // equal political
+                expect(this.player2).not.toBeAbleToSelect(this.daisetsu); // equal political
+                expect(this.player1).not.toBeAbleToSelect(this.solemn); // at home
+
+                this.player2.clickCard(this.prodigy);
+
+                expect(this.prodigy.isParticipating()).toBe(false);
+                expect(this.prodigy.bowed).toBe(true);
+
+                expect(this.getChatLogs(5)).toContain(
+                    'player2 plays To Govern the Land to send Ikoma Prodigy home and bow Ikoma Prodigy'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/ToShowThePath.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/ToShowThePath.spec.js
@@ -1,0 +1,167 @@
+describe('To Show the Path', function () {
+    integration(function () {
+        describe('it when you do not control a monk or shugenja', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['ikoma-prodigy'],
+                        hand: ['to-show-the-path']
+                    }
+                });
+
+                this.prodigy = this.player1.findCardByName('ikoma-prodigy');
+
+                this.toShowThePath = this.player1.findCardByName('to-show-the-path');
+            });
+
+            it('should not trigger', function () {
+                this.player1.clickCard(this.toShowThePath);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+        });
+
+        describe('when there is no non-monk or non-shugenja to target', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja'],
+                        hand: ['to-show-the-path']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+
+                this.toShowThePath = this.player1.findCardByName('to-show-the-path');
+            });
+
+            it('it should not trigger', function () {
+                this.player1.clickCard(this.toShowThePath);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+        });
+
+        describe('when you control a monk or shugenja and there is a valid target', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja', 'togashi-mitsu', 'ikoma-prodigy', 'moto-youth'],
+                        hand: ['to-show-the-path', 'a-perfect-cut', 'a-new-name', 'duelist-training']
+                    },
+                    player2: {
+                        inPlay: ['togashi-ichi', 'isawa-kaede'],
+                        hand: ['a-perfect-cut', 'let-go', 'let-go']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+                this.togashiMitsu = this.player1.findCardByName('togashi-mitsu');
+                this.prodigy = this.player1.findCardByName('ikoma-prodigy');
+
+                this.togashiIchi = this.player2.findCardByName('togashi-ichi');
+                this.isawaKaede = this.player2.findCardByName('isawa-kaede');
+                this.motoYouth = this.player1.findCardByName('moto-youth');
+
+                this.toShowThePath = this.player1.findCardByName('to-show-the-path');
+                this.aPerfectCut1 = this.player1.findCardByName('a-perfect-cut');
+
+                this.aPerfectCut2 = this.player2.findCardByName('a-perfect-cut');
+
+                this.letgo = this.player2.filterCardsByName('let-go')[0];
+                this.letgo2 = this.player2.filterCardsByName('let-go')[1];
+
+                this.ann = this.player1.findCardByName('a-new-name');
+                this.duelist = this.player1.findCardByName('duelist-training');
+            });
+
+            it('it should allow to target a non-monk, non-shugenja owned by either player', function () {
+                this.player1.clickCard(this.toShowThePath);
+                expect(this.player1).toHavePrompt('Choose a character');
+
+                expect(this.player1).toBeAbleToSelect(this.prodigy);
+                expect(this.player1).toBeAbleToSelect(this.motoYouth);
+                expect(this.player1).not.toBeAbleToSelect(this.togashiIchi);
+                expect(this.player1).not.toBeAbleToSelect(this.isawaKaede);
+                expect(this.player1).not.toBeAbleToSelect(this.togashiMitsu);
+                expect(this.player1).not.toBeAbleToSelect(this.doomedShugenja);
+
+                this.player1.clickCard(this.prodigy);
+                expect(this.getChatLogs(3)).toContain(
+                    'player1 plays To Show the Path to make player2 pay 1 additional fate as a cost whenever they target Ikoma Prodigy or its attachments with a card ability until the end of the phase'
+                );
+            });
+
+            it('it should allow to target a non-monk, non-shugenja owned by either player', function () {
+                this.player1.clickCard(this.toShowThePath);
+                expect(this.player1).toHavePrompt('Choose a character');
+
+                this.player1.clickCard(this.motoYouth);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.prodigy, this.motoYouth],
+                    defenders: [],
+                    type: 'military'
+                });
+
+                const player1InitialFate = this.player1.fate;
+                const player2InitialFate = this.player2.fate;
+
+                this.player2.clickCard(this.aPerfectCut2);
+                this.player2.clickCard(this.motoYouth);
+
+                this.player1.clickCard(this.aPerfectCut1);
+                this.player1.clickCard(this.motoYouth);
+
+                expect(this.player1.fate).toBe(player1InitialFate); // no cost increase for the player of To Show the Path
+                expect(this.player2.fate).toBe(player2InitialFate - 1); // cost increase for the opponent
+            });
+
+            it('should also tax attachments that are on the character when the event is played', function () {
+                this.player1.playAttachment(this.duelist, this.motoYouth);
+                this.player2.pass();
+                this.player1.clickCard(this.toShowThePath);
+                this.player1.clickCard(this.motoYouth);
+                expect(this.getChatLogs(3)).toContain(
+                    'player1 plays To Show the Path to make player2 pay 1 additional fate as a cost whenever they target Moto Youth or its attachments with a card ability until the end of the phase'
+                );
+
+                this.player2.pass();
+                this.player1.playAttachment(this.ann, this.motoYouth);
+
+                const fate = this.player2.fate;
+                this.player2.clickCard(this.letgo);
+                this.player2.clickCard(this.duelist);
+                expect(this.player2.fate).toBe(fate - 1); // cost increase for the opponent
+                expect(this.duelist.location).toBe('conflict discard pile');
+            });
+
+            it('also taxes attachments played on the character after Show the Path', function () {
+                this.player1.playAttachment(this.duelist, this.motoYouth);
+
+                this.player2.pass();
+                this.player1.clickCard(this.toShowThePath);
+                this.player1.clickCard(this.motoYouth);
+
+                this.player2.pass();
+                expect(this.ann.location).toBe('hand');
+                this.player1.playAttachment(this.ann, this.motoYouth);
+                expect(this.ann.location).toBe('play area');
+
+                const fate = this.player2.fate;
+                this.player2.clickCard(this.letgo);
+                this.player2.clickCard(this.duelist);
+                expect(this.player2.fate).toBe(fate - 1); // cost increase for the opponent
+                expect(this.duelist.location).toBe('conflict discard pile');
+
+                this.player1.pass();
+                this.player2.clickCard(this.letgo2);
+                this.player2.clickCard(this.ann);
+                expect(this.player2.fate).toBe(fate - 2); // cost increase for the opponent
+                expect(this.ann.location).toBe('conflict discard pile');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/ToSowTheEarth.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/ToSowTheEarth.spec.js
@@ -1,0 +1,63 @@
+describe('To Sow the Earth', function () {
+    integration(function () {
+        describe('peasant replay ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['otter-fisherman'],
+                        dynastyDiscard: ['ashigaru-levy', 'matsu-berserker'],
+                        conflictDiscard: ['ashigaru-company', 'meek-informant'],
+                        hand: ['to-sow-the-earth'],
+                        provinces: ['shameful-display']
+                    },
+                    player2: {
+                        dynastyDiscard: ['militant-faithful']
+                    }
+                });
+
+                this.otterFisherman = this.player1.findCardByName('otter-fisherman');
+                this.ashigaruLevy = this.player1.findCardByName('ashigaru-levy');
+                this.matsuBerserker = this.player1.findCardByName('matsu-berserker');
+                this.ashigaruCompany = this.player1.findCardByName('ashigaru-company');
+                this.meekInformant = this.player1.findCardByName('meek-informant');
+
+                this.toSowTheEarth = this.player1.findCardByName('to-sow-the-earth');
+                this.shameful = this.player1.findCardByName('shameful-display', 'province 1');
+            });
+
+            it('should let you play a peasant character from your discard piles', function () {
+                this.player1.clickCard(this.toSowTheEarth);
+                expect(this.player1).toHavePrompt('Choose a character');
+
+                expect(this.player1).toBeAbleToSelect(this.ashigaruLevy);
+                expect(this.player1).toBeAbleToSelect(this.meekInformant);
+
+                expect(this.player1).not.toBeAbleToSelect(this.matsuBerserker); // not a peasant
+                expect(this.player1).not.toBeAbleToSelect(this.ashigaruCompany); // not a character
+                expect(this.player1).not.toBeAbleToSelect(this.otterFisherman); // in play
+
+                this.player1.clickCard(this.ashigaruLevy);
+                this.player1.clickPrompt('0');
+                expect(this.ashigaruLevy.location).toBe('play area');
+                expect(this.getChatLogs(3)).toContain('player1 plays To Sow the Earth to play Ashigaru Levy from their discard pile');
+            });
+
+            it('should let you bow a peasant to put a province facedown', function () {
+                this.shameful.facedown = false;
+
+                this.player1.clickCard(this.toSowTheEarth);
+                this.player1.clickPrompt('Place a province facedown');
+                expect(this.player1).toHavePrompt('Choose a province');
+                this.player1.clickCard(this.shameful);
+
+                expect(this.player1).toHavePrompt('Select card to bow');
+                this.player1.clickCard(this.otterFisherman);
+
+                expect(this.otterFisherman.bowed).toBe(true);
+                expect(this.shameful.facedown).toBe(true);
+                expect(this.getChatLogs(3)).toContain('player1 plays To Sow the Earth, bowing Otter Fisherman to turn Shameful Display facedown');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/WritOfSanctification.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/WritOfSanctification.spec.js
@@ -1,0 +1,169 @@
+describe('Writ of Sanctification', function () {
+    integration(function () {
+        describe('play restriction', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja', 'ikoma-message-runner'],
+                        hand: ['writ-of-sanctification']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.writOfSanctification = this.player1.findCardByName('writ-of-sanctification');
+            });
+
+            it('should only be able to be played on a shugenja', function () {
+                this.player1.clickCard(this.writOfSanctification);
+                expect(this.player1).toHavePrompt('Choose a card');
+                this.player1.clickCard(this.messageRunner);
+                expect(this.player1).toHavePrompt('Choose a card');
+
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.getChatLogs(5)).toContain('player1 plays Writ of Sanctification, attaching it to Doomed Shugenja');
+            });
+        });
+
+        describe('ancestral keyword', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja', 'ikoma-message-runner'],
+                        hand: ['writ-of-sanctification', 'goblin-sneak', 'obsidian-talisman', 'jealous-ancestor']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.writOfSanctification = this.player1.findCardByName('writ-of-sanctification');
+                this.obsidianTalisman = this.player1.findCardByName('obsidian-talisman');
+                this.goblinSneak = this.player1.findCardByName('goblin-sneak');
+                this.jealousAncestor = this.player1.findCardByName('jealous-ancestor');
+            });
+
+            it('should only have ancestral while you dont control a shadowlands character', function () {
+                this.player1.clickCard(this.writOfSanctification);
+                this.player1.clickCard(this.doomedShugenja);
+
+                expect(this.writOfSanctification.hasKeyword('ancestral')).toBe(true);
+                this.player2.pass();
+
+                this.player1.clickCard(this.obsidianTalisman);
+                this.player1.clickCard(this.doomedShugenja);
+
+                expect(this.writOfSanctification.hasKeyword('ancestral')).toBe(true);
+                this.player2.pass();
+
+                this.player1.clickCard(this.goblinSneak);
+                this.player1.clickPrompt('0');
+                expect(this.writOfSanctification.hasKeyword('ancestral')).toBe(false);
+            });
+
+            it('should only have ancestral while you dont control a haunted character', function () {
+                this.player1.clickCard(this.writOfSanctification);
+                this.player1.clickCard(this.doomedShugenja);
+
+                expect(this.writOfSanctification.hasKeyword('ancestral')).toBe(true);
+                this.player2.pass();
+
+                this.player1.clickCard(this.obsidianTalisman);
+                this.player1.clickCard(this.doomedShugenja);
+
+                expect(this.writOfSanctification.hasKeyword('ancestral')).toBe(true);
+                this.player2.pass();
+
+                this.player1.clickCard(this.jealousAncestor);
+                this.player1.clickPrompt('Play this character');
+                this.player1.clickPrompt('0');
+                expect(this.writOfSanctification.hasKeyword('ancestral')).toBe(false);
+            });
+        });
+
+        describe('gained action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja', 'ikoma-message-runner'],
+                        hand: ['writ-of-sanctification']
+                    },
+                    player2: {
+                        inPlay: ['goblin-sneak', 'jealous-ancestor']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+                this.messageRunner = this.player1.findCardByName('ikoma-message-runner');
+                this.writOfSanctification = this.player1.findCardByName('writ-of-sanctification');
+
+                this.goblinSneak = this.player2.findCardByName('goblin-sneak');
+                this.jealousAncestor = this.player2.findCardByName('jealous-ancestor');
+            });
+
+            it('should not work outside a conflict', function () {
+                this.player1.clickCard(this.writOfSanctification);
+                this.player1.clickCard(this.doomedShugenja);
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.doomedShugenja);
+
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('should not work when the bearer isnt participating', function () {
+                this.player1.clickCard(this.writOfSanctification);
+                this.player1.clickCard(this.doomedShugenja);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.messageRunner],
+                    defenders: [this.goblinSneak],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should not work when the haunted or shadowlands character arent participating', function () {
+                this.player1.clickCard(this.writOfSanctification);
+                this.player1.clickCard(this.doomedShugenja);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.doomedShugenja],
+                    defenders: [],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should be able to target a haunted, tainted or shadowlands participating character', function () {
+                this.player1.clickCard(this.writOfSanctification);
+                this.player1.clickCard(this.doomedShugenja);
+                this.messageRunner.taint();
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.doomedShugenja, this.messageRunner],
+                    defenders: [this.jealousAncestor, this.goblinSneak],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.player1).toBeAbleToSelect(this.goblinSneak);
+                expect(this.player1).toBeAbleToSelect(this.jealousAncestor);
+                expect(this.player1).toBeAbleToSelect(this.messageRunner);
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/WritOfSurvey.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/WritOfSurvey.spec.js
@@ -1,0 +1,171 @@
+describe('Writ of Survey', function () {
+    integration(function () {
+        describe('play restriction', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja', 'matsu-berserker'],
+                        hand: ['writ-of-survey', 'resourcefulness']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+                this.matsuBerserker = this.player1.findCardByName('matsu-berserker');
+                this.writOfSurvey = this.player1.findCardByName('writ-of-survey');
+                this.resourcefulness = this.player1.findCardByName('resourcefulness');
+            });
+
+            it('should only be able to be played on a honored character', function () {
+                this.doomedShugenja.honor();
+                this.game.checkGameState(true);
+                this.player1.clickCard(this.writOfSurvey);
+                expect(this.player1).toHavePrompt('Choose a card');
+                this.player1.clickCard(this.matsuBerserker);
+                expect(this.player1).toHavePrompt('Choose a card');
+
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.getChatLogs(5)).toContain('player1 plays Writ of Survey, attaching it to Doomed Shugenja');
+            });
+
+            it('should not fall off when dishonored', function () {
+                this.doomedShugenja.honor();
+                this.game.checkGameState(true);
+                this.player1.clickCard(this.writOfSurvey);
+                expect(this.player1).toHavePrompt('Choose a card');
+                this.player1.clickCard(this.matsuBerserker);
+                expect(this.player1).toHavePrompt('Choose a card');
+
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.getChatLogs(5)).toContain('player1 plays Writ of Survey, attaching it to Doomed Shugenja');
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.resourcefulness);
+                this.player1.clickCard(this.matsuBerserker);
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.getChatLogs(5)).toContain('player1 plays Resourcefulness, dishonoring Doomed Shugenja to honor Matsu Berserker');
+                expect(this.doomedShugenja.isHonored).toBe(false);
+                expect(this.writOfSurvey.parent).toBe(this.doomedShugenja);
+            });
+        });
+
+        describe('ancestral keyword', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja', 'matsu-berserker'],
+                        hand: ['writ-of-survey']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+                this.matsuBerserker = this.player1.findCardByName('matsu-berserker');
+                this.writOfSurvey = this.player1.findCardByName('writ-of-survey');
+            });
+
+            it('should only have ancestral while the parent is honored', function () {
+                this.doomedShugenja.honor();
+                this.player1.clickCard(this.writOfSurvey);
+                this.player1.clickCard(this.doomedShugenja);
+
+                expect(this.writOfSurvey.hasKeyword('ancestral')).toBe(true);
+                this.doomedShugenja.dishonor();
+                this.player2.pass();
+
+                expect(this.writOfSurvey.hasKeyword('ancestral')).toBe(false);
+            });
+        });
+
+        describe('gained action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['doomed-shugenja', 'matsu-berserker'],
+                        hand: ['writ-of-survey']
+                    },
+                    player2: {
+                        inPlay: ['goblin-sneak', 'jealous-ancestor']
+                    }
+                });
+
+                this.doomedShugenja = this.player1.findCardByName('doomed-shugenja');
+                this.matsuBerserker = this.player1.findCardByName('matsu-berserker');
+                this.writOfSurvey = this.player1.findCardByName('writ-of-survey');
+
+                this.goblinSneak = this.player2.findCardByName('goblin-sneak');
+                this.jealousAncestor = this.player2.findCardByName('jealous-ancestor');
+
+                this.doomedShugenja.honor();
+                this.goblinSneak.dishonor();
+            });
+
+            it('should not work outside a conflict', function () {
+                this.player1.clickCard(this.writOfSurvey);
+                this.player1.clickCard(this.doomedShugenja);
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.doomedShugenja);
+
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('should not work when the bearer isnt participating', function () {
+                this.player1.clickCard(this.writOfSurvey);
+                this.player1.clickCard(this.doomedShugenja);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.matsuBerserker],
+                    defenders: [this.goblinSneak],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should not work when there isnt a participating dishonored character', function () {
+                this.player1.clickCard(this.writOfSurvey);
+                this.player1.clickCard(this.doomedShugenja);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.doomedShugenja],
+                    defenders: [this.jealousAncestor],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+            });
+
+            it('should be able to target a dishonored participating character and bow it', function () {
+                this.player1.clickCard(this.writOfSurvey);
+                this.player1.clickCard(this.doomedShugenja);
+
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.doomedShugenja, this.matsuBerserker],
+                    defenders: [this.jealousAncestor, this.goblinSneak],
+                    type: 'military'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.doomedShugenja);
+                expect(this.player1).toBeAbleToSelect(this.goblinSneak);
+                expect(this.player1).not.toBeAbleToSelect(this.jealousAncestor);
+                expect(this.player1).not.toBeAbleToSelect(this.matsuBerserker);
+                expect(this.player1).not.toBeAbleToSelect(this.doomedShugenja);
+
+                this.player1.clickCard(this.goblinSneak);
+                expect(this.goblinSneak.bowed).toBe(true);
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Neutral/YatakabunePort.spec.js
+++ b/test/server/cards/19.1-AS01/Neutral/YatakabunePort.spec.js
@@ -1,0 +1,41 @@
+describe('Jade-Colored Rocks', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['isawa-tadaka'],
+                    hand: ['a-new-name']
+                },
+                player2: {
+                    provinces: ['yatakabune-port']
+                }
+            });
+
+            this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+            this.ann = this.player1.findCardByName('a-new-name');
+
+            this.port = this.player2.findCardByName('yatakabune-port');
+        });
+
+        it('should claim favor when broken', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.port,
+                type: 'military'
+            });
+
+            this.noMoreActions();
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.port);
+
+            this.player2.clickCard(this.port);
+            this.player2.clickPrompt('military');
+            expect(this.player2.player.imperialFavor).toBe('military');
+            expect(this.getChatLogs(10)).toContain('player2 claims the Emperor\'s military favor!');
+            expect(this.getChatLogs(10)).toContain('player2 uses Yatakabune Port to claim the Emperor\'s favor');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/CeremonialRobes.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/CeremonialRobes.spec.js
@@ -1,0 +1,130 @@
+describe('Ceremonial Robes', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['ceremonial-robes', 'kami-of-ancient-wisdom', 'solemn-scholar', 'guardian-dojo'],
+                    dynastyDiscard: ['fushicho']
+                }
+            });
+
+            this.robes = this.player1.findCardByName('ceremonial-robes');
+
+            this.kami = this.player1.findCardByName('kami-of-ancient-wisdom');
+            this.solemn = this.player1.findCardByName('solemn-scholar');
+            this.dojo = this.player1.findCardByName('guardian-dojo');
+
+            this.player1.moveCard('fushicho', 'dynasty deck');
+
+            this.prov1 = this.player1.findCardByName('shameful-display', 'province 1');
+            this.prov2 = this.player1.findCardByName('shameful-display', 'province 2');
+            this.prov3 = this.player1.findCardByName('shameful-display', 'province 3');
+            this.prov4 = this.player1.findCardByName('shameful-display', 'province 4');
+            this.provSH = this.player1.findCardByName('shameful-display', 'stronghold province');
+        });
+
+        it('gains glory for each spirit character player controls', function () {
+            expect(this.robes.glory).toBe(2);
+        });
+
+        it('filters cards, put 1 in a non-sh province', function () {
+            this.player1.player.moveCard(this.kami, 'dynasty deck');
+            this.player1.player.moveCard(this.solemn, 'dynasty deck');
+            this.player1.player.moveCard(this.dojo, 'dynasty deck');
+
+            let p1InitialHonor = this.player1.honor;
+            let p2InitialHonor = this.player2.honor;
+
+            this.player1.clickCard(this.robes);
+            expect(this.player1).toHavePrompt('Choose a province');
+            expect(this.player1).toBeAbleToSelect(this.prov1);
+            expect(this.player1).toBeAbleToSelect(this.prov2);
+            expect(this.player1).toBeAbleToSelect(this.prov3);
+            expect(this.player1).toBeAbleToSelect(this.prov4);
+            expect(this.player1).not.toBeAbleToSelect(this.provSH);
+
+            this.player1.clickCard(this.prov1);
+            expect(this.player1).toHavePrompt('Select a card to put into the province faceup');
+            expect(this.player1).toHavePromptButton('Guardian Dōjō');
+            expect(this.player1).toHavePromptButton('Solemn Scholar');
+            expect(this.player1).toHavePromptButton('Kami of Ancient Wisdom');
+
+            this.player1.clickPrompt('Guardian Dōjō');
+            expect(this.dojo.location).toBe('province 1');
+            expect(this.dojo.facedown).toBe(false);
+
+            expect(this.player1).toHavePrompt('Select a card to put on the bottom of the deck');
+            expect(this.player1).not.toHavePromptButton('Guardian Dōjō');
+            expect(this.player1).toHavePromptButton('Solemn Scholar');
+            expect(this.player1).toHavePromptButton('Kami of Ancient Wisdom');
+
+            this.player1.clickPrompt('Kami of Ancient Wisdom');
+            expect(this.kami.location).toBe('dynasty deck');
+
+            expect(this.solemn.location).toBe('dynasty discard pile');
+            expect(this.player1.honor).toBe(p1InitialHonor);
+            expect(this.player2.honor).toBe(p2InitialHonor);
+
+            expect(this.player1).toHavePrompt('Waiting for opponent to take an action or pass');
+
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Ceremonial Robes to look at the top 3 cards of their dynasty deck'
+            );
+            expect(this.getChatLogs(5)).toContain('player1 places a card on the bottom of the deck');
+            expect(this.getChatLogs(5)).toContain('player1 places Guardian Dōjō into their province');
+            expect(this.getChatLogs(5)).toContain('player1 discards Solemn Scholar');
+        });
+
+        it('filters cards, put 1 in a non-sh province, and make players lose honor when discarding a spirit', function () {
+            this.player1.player.moveCard(this.kami, 'dynasty deck');
+            this.player1.player.moveCard(this.solemn, 'dynasty deck');
+            this.player1.player.moveCard(this.dojo, 'dynasty deck');
+
+            let p1InitialHonor = this.player1.honor;
+            let p2InitialHonor = this.player2.honor;
+
+            this.player1.clickCard(this.robes);
+            expect(this.player1).toHavePrompt('Choose a province');
+            expect(this.player1).toBeAbleToSelect(this.prov1);
+            expect(this.player1).toBeAbleToSelect(this.prov2);
+            expect(this.player1).toBeAbleToSelect(this.prov3);
+            expect(this.player1).toBeAbleToSelect(this.prov4);
+            expect(this.player1).not.toBeAbleToSelect(this.provSH);
+
+            this.player1.clickCard(this.prov1);
+            expect(this.player1).toHavePrompt('Select a card to put into the province faceup');
+            expect(this.player1).toHavePromptButton('Guardian Dōjō');
+            expect(this.player1).toHavePromptButton('Solemn Scholar');
+            expect(this.player1).toHavePromptButton('Kami of Ancient Wisdom');
+
+            this.player1.clickPrompt('Solemn Scholar');
+            expect(this.solemn.location).toBe('province 1');
+            expect(this.solemn.facedown).toBe(false);
+
+            expect(this.player1).toHavePrompt('Select a card to put on the bottom of the deck');
+            expect(this.player1).toHavePromptButton('Guardian Dōjō');
+            expect(this.player1).toHavePromptButton('Kami of Ancient Wisdom');
+            expect(this.player1).not.toHavePromptButton('Solemn Scholar');
+
+            this.player1.clickPrompt('Guardian Dōjō');
+            expect(this.dojo.location).toBe('dynasty deck');
+
+            expect(this.kami.location).toBe('dynasty discard pile');
+            expect(this.player1.honor).toBe(p1InitialHonor - 1);
+            expect(this.player2.honor).toBe(p2InitialHonor - 1);
+
+            expect(this.player1).toHavePrompt('Waiting for opponent to take an action or pass');
+
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Ceremonial Robes to look at the top 3 cards of their dynasty deck'
+            );
+            expect(this.getChatLogs(5)).toContain('player1 places a card on the bottom of the deck');
+            expect(this.getChatLogs(5)).toContain('player1 places Solemn Scholar into their province');
+            expect(this.getChatLogs(5)).toContain('player1 discards Kami of Ancient Wisdom');
+            expect(this.getChatLogs(5)).toContain(
+                'Kami of Ancient Wisdom was a Spirit! player1 and player2 lose 1 honor'
+            );
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/Firebrand.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/Firebrand.spec.js
@@ -1,0 +1,60 @@
+describe('Firebrand', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['firebrand', 'isawa-tadaka']
+                },
+                player2: {
+                    inPlay: ['solemn-scholar', 'kitsu-motso']
+                }
+            });
+
+            this.firebrand = this.player1.findCardByName('firebrand');
+            this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+
+            this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+            this.kitsuMotso = this.player2.findCardByName('kitsu-motso');
+        });
+
+        it('should return the fire ring and resolve the fire ring effect', function() {
+            this.player1.claimRing('earth');
+            this.player1.claimRing('fire');
+            this.game.checkGameState(true);
+            this.player1.clickCard(this.firebrand);
+            expect(this.player1).not.toBeAbleToSelectRing('air');
+            expect(this.player1).not.toBeAbleToSelectRing('earth');
+            expect(this.player1).toBeAbleToSelectRing('fire');
+            expect(this.player1).not.toBeAbleToSelectRing('void');
+            expect(this.player1).not.toBeAbleToSelectRing('water');
+            this.player1.clickRing('fire');
+
+            expect(this.player1).toHavePrompt('Fire Ring');
+            expect(this.player1).toHavePrompt('Choose character to honor or dishonor');
+
+            this.player1.clickCard(this.isawaTadaka);
+            this.player1.clickPrompt('Honor Isawa Tadaka');
+            expect(this.isawaTadaka.isHonored).toBe(true);
+
+            expect(this.getChatLogs(5)).toContain('player1 uses Firebrand, returning the Fire Ring to resolve the Fire Ring effect');
+            expect(this.getChatLogs(5)).toContain('player1 resolves the fire ring, honoring Isawa Tadaka');
+        });
+
+        it('should not work if you don\'t have the fire ring claimed', function() {
+            this.player1.claimRing('earth');
+            this.game.checkGameState(true);
+            expect(this.player1).toHavePrompt('Action Window');
+            this.player1.clickCard(this.firebrand);
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+
+        it('should not work if opponent has the fire ring claimed', function() {
+            this.player2.claimRing('fire');
+            this.game.checkGameState(true);
+            expect(this.player1).toHavePrompt('Action Window');
+            this.player1.clickCard(this.firebrand);
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/GregariousWard.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/GregariousWard.spec.js
@@ -1,0 +1,76 @@
+describe('Gregarious Ward', function () {
+    integration(function () {
+        describe('Gregarious Ward\'s ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        fate: 3,
+                        inPlay: ['gregarious-ward']
+                    },
+                    player2: {
+                        inPlay: [
+                            'borderlands-defender',
+                            'steadfast-witch-hunter'
+                        ]
+                    }
+                });
+
+                this.gregariousWard =
+                    this.player1.findCardByName('gregarious-ward');
+
+                this.borderlandsDefender = this.player2.findCardByName(
+                    'borderlands-defender'
+                );
+                this.steadfastWitchHunter = this.player2.findCardByName(
+                    'steadfast-witch-hunter'
+                );
+
+                this.shamefulDisplay = this.player2.findCardByName(
+                    'shameful-display',
+                    'province 1'
+                );
+
+                this.noMoreActions();
+            });
+
+            it('should trigger after winning a conflict where controller has more participants than the opponent', function () {
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.gregariousWard],
+                    defenders: [],
+                    province: this.shamefulDisplay
+                });
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+                this.player1.clickCard(this.gregariousWard);
+                expect(this.gregariousWard.fate).toBe(1);
+            });
+
+            it('should not trigger after winning a conflict where controller has less or equal participants than the opponent', function () {
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.gregariousWard],
+                    defenders: [this.steadfastWitchHunter]
+                });
+                this.noMoreActions();
+                expect(this.gregariousWard.fate).toBe(0);
+            });
+
+            it('should not trigger after losing a conflict', function () {
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.gregariousWard],
+                    defenders: [
+                        this.borderlandsDefender,
+                        this.steadfastWitchHunter
+                    ]
+                });
+                this.noMoreActions();
+                expect(this.game.currentConflict).toBeNull();
+                expect(this.player1).toHavePrompt('Action Window');
+                expect(this.gregariousWard.fate).toBe(0);
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/ParanoidHososhi.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/ParanoidHososhi.spec.js
@@ -1,0 +1,69 @@
+describe('Paranoid Hososhi', function () {
+    integration(function () {
+        describe('Fate stealing ability', function () {
+            describe('When your opponent have the highest cost character and they have fate', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            inPlay: ['paranoid-hososhi']
+                        },
+                        player2: {
+                            inPlay: ['shiba-tsukune']
+                        }
+                    });
+
+                    this.paranoidHososhi = this.player1.findCardByName('paranoid-hososhi');
+                    this.paranoidHososhi.fate = 1;
+
+                    this.tsukune = this.player2.findCardByName('shiba-tsukune');
+                    this.tsukune.fate = 1;
+                    this.flow.finishConflictPhase();
+                });
+
+                it('is triggerable', function () {
+                    let player1FateBefore = this.player1.fate;
+                    this.player1.clickCard(this.paranoidHososhi);
+                    expect(this.player1).toHavePrompt('Paranoid Hōsōshi');
+                    expect(this.player1).toBeAbleToSelect(this.tsukune);
+                    expect(this.player1).not.toBeAbleToSelect(this.paranoidHososhi);
+
+                    this.player1.clickCard(this.tsukune);
+                    expect(this.paranoidHososhi.bowed).toBe(true);
+                    expect(this.tsukune.fate).toBe(0);
+                    expect(this.player1.fate).toBe(player1FateBefore + 1);
+
+                    expect(this.getChatLogs(3)).toContain(
+                        'player1 uses Paranoid Hōsōshi, bowing Paranoid Hōsōshi to take 1 fate from Shiba Tsukune — evil begone!'
+                    );
+                });
+            });
+
+            describe('When your opponent have the highest cost character and they have no fate', function () {
+                beforeEach(function () {
+                    this.setupTest({
+                        phase: 'conflict',
+                        player1: {
+                            inPlay: ['paranoid-hososhi']
+                        },
+                        player2: {
+                            inPlay: ['shiba-tsukune']
+                        }
+                    });
+
+                    this.paranoidHososhi = this.player1.findCardByName('paranoid-hososhi');
+                    this.paranoidHososhi.fate = 1;
+
+                    this.tsukune = this.player2.findCardByName('shiba-tsukune');
+                    this.tsukune.fate = 0;
+                    this.flow.finishConflictPhase();
+                });
+
+                it('is not triggerable', function () {
+                    this.player1.clickCard(this.paranoidHososhi);
+                    expect(this.player1).not.toHavePrompt('Paranoid Hōsōshi');
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/ServitorOfStone.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/ServitorOfStone.spec.js
@@ -1,0 +1,123 @@
+describe('Servitor of Stone', function () {
+    integration(function () {
+        describe('While it has a shugenja with it', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['servitor-of-stone', 'solemn-scholar']
+                    },
+                    player2: {
+                        inPlay: [],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.servitorOfStone =
+                    this.player1.findCardByName('servitor-of-stone');
+                this.solemn = this.player1.findCardByName('solemn-scholar');
+                this.assassination =
+                    this.player2.findCardByName('assassination');
+            });
+
+            it('cannot be discarded by actions', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.servitorOfStone, this.solemn],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.assassination);
+                expect(this.player2).toBeAbleToSelect(this.solemn);
+                expect(this.servitorOfStone.location).toBe('play area');
+                expect(this.player2).not.toBeAbleToSelect(this.servitorOfStone);
+            });
+
+            it('cannot be discarded by the fate phase discard', function () {
+                this.solemn.fate = 1;
+                this.flow.finishConflictPhase();
+                expect(this.player1).toHavePrompt(
+                    'Select dynasty cards to discard'
+                );
+                expect(this.solemn.location).toBe('play area');
+                expect(this.solemn.fate).toBe(0);
+                expect(this.player1).not.toBeAbleToSelect(this.solemn);
+                expect(this.servitorOfStone.fate).toBe(0);
+                expect(this.player1).not.toBeAbleToSelect(this.servitorOfStone);
+            });
+        });
+
+        describe('When it does not have a shugenja with it', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: [
+                            'servitor-of-stone',
+                            'solemn-scholar',
+                            'keeper-initiate'
+                        ]
+                    },
+                    player2: {
+                        inPlay: [],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.servitorOfStone =
+                    this.player1.findCardByName('servitor-of-stone');
+                this.solemn = this.player1.findCardByName('solemn-scholar');
+                this.keeperInitiate =
+                    this.player1.findCardByName('keeper-initiate');
+                this.assassination =
+                    this.player2.findCardByName('assassination');
+            });
+
+            it('gets discarded if their shugenja is discarded', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.servitorOfStone, this.solemn],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.assassination);
+                this.player2.clickCard(this.solemn);
+                expect(this.servitorOfStone.location).toBe(
+                    'conflict discard pile'
+                );
+                expect(this.getChatLogs(3)).toContain(
+                    'Servitor of Stone is discarded from play because player1 controls no Shugenja at their location'
+                );
+            });
+
+            it('gets discarded if it initiates a conflict without a shugenja', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.servitorOfStone, this.keeperInitiate],
+                    defenders: []
+                });
+
+                expect(this.servitorOfStone.location).toBe(
+                    'conflict discard pile'
+                );
+                expect(this.getChatLogs(5)).toContain(
+                    'Servitor of Stone is discarded from play because player1 controls no Shugenja at their location'
+                );
+            });
+
+            it('gets discarded during the fate phase even if it has fate, if there is not shugenja with it', function () {
+                this.servitorOfStone.fate = 1;
+                this.flow.finishConflictPhase();
+                this.player1.clickPrompt('Done');
+
+                expect(this.solemn.location).toBe('dynasty discard pile');
+                expect(this.servitorOfStone.location).toBe(
+                    'conflict discard pile'
+                );
+                expect(this.getChatLogs(5)).toContain(
+                    'Servitor of Stone is discarded from play because player1 controls no Shugenja at their location'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/ShibasOath.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/ShibasOath.spec.js
@@ -1,0 +1,256 @@
+describe('Shiba\'s Oath', function () {
+    integration(function () {
+        describe('play restriction', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['solemn-scholar', 'serene-warrior'],
+                        hand: ['shiba-s-oath']
+                    }
+                });
+
+                this.solemnScholar = this.player1.findCardByName('solemn-scholar');
+                this.sereneWarrior = this.player1.findCardByName('serene-warrior');
+                this.shibasOath = this.player1.findCardByName('shiba-s-oath');
+            });
+
+            it('should only be able to be played on a bushi', function () {
+                this.player1.clickCard(this.shibasOath);
+                expect(this.player1).toHavePrompt('Choose a card');
+                this.player1.clickCard(this.solemnScholar);
+                expect(this.player1).toHavePrompt('Choose a card');
+
+                this.player1.clickCard(this.sereneWarrior);
+                expect(this.getChatLogs(5)).toContain('player1 plays Shiba\'s Oath, attaching it to Serene Warrior');
+            });
+        });
+
+        describe('Conflict hase Ancestral keyword', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['solemn-scholar', 'serene-warrior'],
+                        hand: ['shiba-s-oath']
+                    }
+                });
+                this.solemnScholar = this.player1.findCardByName('solemn-scholar');
+                this.sereneWarrior = this.player1.findCardByName('serene-warrior');
+                this.shibasOath = this.player1.findCardByName('shiba-s-oath');
+                this.game.checkGameState(true);
+            });
+
+            it('should gain ancestral in the conflict phase', function () {
+                this.player1.clickCard(this.shibasOath);
+                this.player1.clickCard(this.sereneWarrior);
+
+                this.player1.clickCard(this.shibasOath);
+
+                expect(this.shibasOath.hasKeyword('ancestral')).toBe(true);
+
+                this.flow.finishConflictPhase();
+                expect(this.shibasOath.hasKeyword('ancestral')).toBe(false);
+            });
+        });
+
+        describe('reaction when enter play', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['serene-warrior'],
+                        hand: ['shiba-s-oath']
+                    }
+                });
+
+                this.sereneWarrior = this.player1.findCardByName('serene-warrior');
+                this.shibasOath = this.player1.findCardByName('shiba-s-oath');
+            });
+
+            it('should honor the attached character', function () {
+                this.player1.clickCard(this.shibasOath);
+                this.player1.clickCard(this.sereneWarrior);
+                this.player1.clickCard(this.shibasOath);
+                expect(this.sereneWarrior.isHonored).toBe(true);
+                expect(this.getChatLogs(5)).toContain('player1 uses Shiba\'s Oath to honor Serene Warrior');
+            });
+        });
+
+        describe('Interrupt gained ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['valiant-oathkeeper', 'solemn-scholar', 'fearless-sailor'],
+                        hand: ['shiba-s-oath']
+                    },
+                    player2: {
+                        inPlay: ['doji-kuwanan', 'political-rival'],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.valiantOathkeeper = this.player1.findCardByName('valiant-oathkeeper');
+                this.sailor = this.player1.findCardByName('fearless-sailor');
+                this.solemnScholar = this.player1.findCardByName('solemn-scholar');
+                this.shibasOath = this.player1.findCardByName('shiba-s-oath');
+                this.shamefulDisplay = this.player1.findCardByName('shameful-display', 'province 1');
+
+                this.politicalRival = this.player2.findCardByName('political-rival');
+                this.kuwanan = this.player2.findCardByName('doji-kuwanan');
+                this.assassination = this.player2.findCardByName('assassination');
+
+                this.player1.clickCard(this.shibasOath);
+                this.player1.clickCard(this.valiantOathkeeper);
+                this.player1.clickCard(this.shibasOath);
+            });
+
+            it('cancel events on non-bushi with both chars in conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.valiantOathkeeper, this.solemnScholar, this.sailor],
+                    defenders: [this.kuwanan]
+                });
+
+                this.player2.clickCard(this.assassination);
+                this.player2.clickCard(this.solemnScholar);
+                expect(this.player1).toHavePrompt('Any interrupts to the effects of Assassination?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Assassination'
+                );
+            });
+
+            it('does not cancel events on other bushi at same location', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.valiantOathkeeper, this.solemnScholar, this.sailor],
+                    defenders: [this.kuwanan]
+                });
+
+                this.player2.clickCard(this.assassination);
+                this.player2.clickCard(this.sailor);
+                expect(this.player1).not.toHavePrompt('Any interrupts to the effects of Assassination?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).not.toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Assassination'
+                );
+            });
+
+            it('cancel events when the bushi and the non-bushi are in different locations', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.solemnScholar, this.sailor],
+                    defenders: [this.kuwanan]
+                });
+
+                this.player2.clickCard(this.assassination);
+                this.player2.clickCard(this.solemnScholar);
+                expect(this.player1).toHavePrompt('Any interrupts to the effects of Assassination?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Assassination'
+                );
+            });
+
+            it('cancel character abilities on non-bushi with both chars in conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.valiantOathkeeper, this.solemnScholar, this.sailor],
+                    defenders: [this.kuwanan]
+                });
+
+                this.player2.clickCard(this.kuwanan);
+                this.player2.clickCard(this.solemnScholar);
+                expect(this.player1).toHavePrompt('Any interrupts to the effects of Doji Kuwanan?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Doji Kuwanan'
+                );
+            });
+
+            it('does not cancel character abilities on other bushi at same location', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.valiantOathkeeper, this.solemnScholar, this.sailor],
+                    defenders: [this.kuwanan]
+                });
+
+                this.player2.clickCard(this.kuwanan);
+                this.player2.clickCard(this.sailor);
+                expect(this.player1).not.toHavePrompt('Any interrupts to the effects of Doji Kuwanan?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).not.toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Doji Kuwanan'
+                );
+            });
+
+            it('cancel character abilities when the bushi and the non-bushi are in different locations', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.solemnScholar, this.sailor],
+                    defenders: [this.kuwanan]
+                });
+
+                this.player2.clickCard(this.kuwanan);
+                this.player2.clickCard(this.solemnScholar);
+                expect(this.player1).toHavePrompt('Any interrupts to the effects of Doji Kuwanan?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Doji Kuwanan'
+                );
+            });
+
+            it('cancel character static abilities on non-bushi with both chars in conflict', function () {
+                this.noMoreActions();
+                this.player1.clickPrompt('Pass Conflict');
+                this.player1.clickPrompt('Yes');
+
+                this.noMoreActions();
+
+                this.player2.clickRing('earth');
+                this.player2.clickCard(this.shamefulDisplay);
+                this.player2.clickCard(this.politicalRival);
+                this.player2.clickPrompt('Initiate Conflict');
+                expect(this.player2).toHavePrompt('Choose covert target for Political Rival');
+
+                this.player2.clickCard(this.solemnScholar);
+                expect(this.player1).toHavePrompt('Any interrupts to the effects of Political Rival?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Political Rival'
+                );
+            });
+
+            it('does not cancel character static abilities on other bushi at same location', function () {
+                this.noMoreActions();
+                this.player1.clickPrompt('Pass Conflict');
+                this.player1.clickPrompt('Yes');
+
+                this.noMoreActions();
+
+                this.player2.clickRing('earth');
+                this.player2.clickCard(this.shamefulDisplay);
+                this.player2.clickCard(this.politicalRival);
+                this.player2.clickPrompt('Initiate Conflict');
+                expect(this.player2).toHavePrompt('Choose covert target for Political Rival');
+
+                this.player2.clickCard(this.sailor);
+                expect(this.player1).not.toHavePrompt('Any interrupts to the effects of Political Rival?');
+
+                this.player1.clickCard(this.valiantOathkeeper);
+                expect(this.getChatLogs(5)).not.toContain(
+                    'player1 uses Valiant Oathkeeper\'s gained ability from Shiba\'s Oath, sacrificing Valiant Oathkeeper to cancel the effects of Political Rival'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/TheEmptyCity.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/TheEmptyCity.spec.js
@@ -1,0 +1,124 @@
+describe('The Empty City', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    provinces: ['the-empty-city'],
+                    inPlay: ['adept-of-the-waves', 'fushicho'],
+                    hand: [],
+                    dynastyDiscard: ['crafty-tsukumogami', 'kami-of-ancient-wisdom', 'solemn-scholar'],
+                    conflictDiscard: ['guardian-kami', 'ishiken-initiate']
+                },
+                player2: {
+                    hand: ['assassination']
+                }
+            });
+
+            this.theEmptyCity = this.player1.findCardByName('the-empty-city', 'province 1');
+
+            this.fushicho = this.player1.findCardByName('fushicho');
+            this.adeptOfTheWaves = this.player1.findCardByName('adept-of-the-waves');
+            this.tsukumogami = this.player1.findCardByName('crafty-tsukumogami', 'dynasty discard pile');
+            this.kamiAncient = this.player1.findCardByName('kami-of-ancient-wisdom', 'dynasty discard pile');
+            this.solemnScholar = this.player1.findCardByName('solemn-scholar', 'dynasty discard pile');
+            this.guardianKami = this.player1.findCardByName('guardian-kami', 'conflict discard pile');
+            this.ishikenInitiate = this.player1.findCardByName('ishiken-initiate', 'conflict discard pile');
+
+            this.assassination = this.player2.findCardByName('assassination');
+
+            this.player1.claimRing('earth');
+            this.player2.claimRing('water');
+        });
+
+        it('claims an unclaimed ring', function () {
+            this.player1.clickCard(this.theEmptyCity);
+            expect(this.player1).toHavePrompt('The Empty City');
+            expect(this.player1).toHavePromptButton('Claim a ring');
+            expect(this.player1).toHavePromptButton('Put a Spirit character into play');
+            this.player1.clickPrompt('Claim a ring');
+
+            expect(this.player1).toBeAbleToSelectRing('air');
+            expect(this.player1).toBeAbleToSelectRing('void');
+            expect(this.player1).toBeAbleToSelectRing('fire');
+            expect(this.player1).not.toBeAbleToSelectRing('earth');
+            expect(this.player1).not.toBeAbleToSelectRing('water');
+
+            this.player1.clickRing('air');
+            this.player1.clickCard(this.fushicho);
+            expect(this.fushicho.bowed).toBe(true);
+            expect(this.game.rings.air.conflictType).toBe('political');
+            expect(this.game.rings.air.isClaimed()).toBe(true);
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses The Empty City, bowing Fushichō to claim Air Ring as a political ring'
+            );
+        });
+
+        it('puts a spirit character into play', function () {
+            this.player1.clickCard(this.theEmptyCity);
+            expect(this.player1).toHavePrompt('The Empty City');
+            expect(this.player1).toHavePromptButton('Claim a ring');
+            expect(this.player1).toHavePromptButton('Put a Spirit character into play');
+            this.player1.clickPrompt('Put a Spirit character into play');
+
+            expect(this.player1).not.toBeAbleToSelect(this.fushicho);
+            expect(this.player1).not.toBeAbleToSelect(this.adeptOfTheWaves);
+            expect(this.player1).toBeAbleToSelect(this.tsukumogami);
+            expect(this.player1).not.toBeAbleToSelect(this.kamiAncient);
+            expect(this.player1).not.toBeAbleToSelect(this.solemnScholar);
+            expect(this.player1).toBeAbleToSelect(this.guardianKami);
+            expect(this.player1).not.toBeAbleToSelect(this.ishikenInitiate);
+
+            this.player1.clickCard(this.guardianKami);
+            expect(this.guardianKami.location).toBe('play area');
+            expect(this.getChatLogs(5)).toContain('player1 uses The Empty City to put Guardian Kami into play');
+        });
+
+        it('after putting a spirit into play, remove it from the game the next time it leaves play in that round', function () {
+            expect(this.guardianKami.location).toBe('conflict discard pile');
+            this.player1.clickCard(this.theEmptyCity);
+            this.player1.clickPrompt('Put a Spirit character into play');
+            this.player1.clickCard(this.guardianKami);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                type: 'military',
+                attackers: [this.guardianKami],
+                defenders: []
+            });
+
+            this.player2.clickCard(this.assassination);
+            this.player2.clickCard(this.guardianKami);
+
+            expect(this.guardianKami.location).toBe('removed from game');
+            expect(this.getChatLogs(5)).toContain(
+                'Guardian Kami is removed from the game, as it was invoked by the The Empty City this round'
+            );
+        });
+
+        it('can only use one of ability per round - claim first', function () {
+            this.player1.clickCard(this.theEmptyCity);
+            this.player1.clickPrompt('Claim a ring');
+            this.player1.clickRing('air');
+            this.player1.clickCard(this.fushicho);
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses The Empty City, bowing Fushichō to claim Air Ring as a political ring'
+            );
+
+            this.player2.pass();
+            this.player1.clickCard(this.theEmptyCity);
+            expect(this.player1).not.toHavePrompt('The Empty City');
+        });
+
+        it('can only use one of ability per round - put in play first', function () {
+            this.player1.clickCard(this.theEmptyCity);
+            this.player1.clickPrompt('Put a Spirit character into play');
+            this.player1.clickCard(this.tsukumogami);
+            expect(this.getChatLogs(5)).toContain('player1 uses The Empty City to put Crafty Tsukumogami into play');
+
+            this.player2.pass();
+            this.player1.clickCard(this.theEmptyCity);
+            expect(this.player1).not.toHavePrompt('The Empty City');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Phoenix/VigilantGuardian.spec.js
+++ b/test/server/cards/19.1-AS01/Phoenix/VigilantGuardian.spec.js
@@ -1,0 +1,77 @@
+describe('Vigilant Guardian', function () {
+    integration(function () {
+        describe('Vigilant Guardian\'s ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['steward-of-law','asahina-diviner'],
+                        dynastyDiscard: ['iuchi-soulweaver', 'iuchi-soulweaver']
+                    },
+                    player2: {
+                        inPlay: ['vigilant-guardian'],
+                        hand: ['rout']
+                    }
+                });
+
+                this.steward = this.player1.findCardByName('steward-of-law');
+                this.asahinaDiviner = this.player1.findCardByName('asahina-diviner');
+                this.soulweaver1 =
+                    this.player1.filterCardsByName('iuchi-soulweaver')[0];
+                this.soulweaver2 =
+                    this.player1.filterCardsByName('iuchi-soulweaver')[1];
+
+                this.vigilantGuardian =
+                    this.player2.findCardByName('vigilant-guardian');
+                this.rout = this.player2.findCardByName('rout');
+                this.noMoreActions();
+            });
+
+            it('bows when defending vs an attacker', function () {
+                this.initiateConflict({
+                    attackers: [this.steward],
+                    defenders: [this.vigilantGuardian]
+                });
+                this.noMoreActions();
+                expect(this.vigilantGuardian.bowed).toBe(true);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('bows when defending vs an attack with characters that participate from home', function () {
+                this.player1.putIntoPlay(this.soulweaver1);
+                this.player1.putIntoPlay(this.soulweaver2);
+                this.initiateConflict({
+                    attackers: [this.steward],
+                    defenders: [this.vigilantGuardian]
+                });
+                this.player2.clickCard(this.rout);
+                this.player2.clickCard(this.steward);
+                this.noMoreActions();
+                expect(this.vigilantGuardian.bowed).toBe(true);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('does not bow when defending vs no attackers', function () {
+                this.initiateConflict({
+                    attackers: [this.steward],
+                    defenders: [this.vigilantGuardian]
+                });
+                this.player2.clickCard(this.rout);
+                this.player2.clickCard(this.steward);
+                this.noMoreActions();
+                expect(this.vigilantGuardian.bowed).toBe(false);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+
+            it('does not bow when defending vs attackers that sum zero skill', function () {
+                this.initiateConflict({
+                    attackers: [this.asahinaDiviner],
+                    defenders: [this.vigilantGuardian]
+                });
+                this.noMoreActions();
+                expect(this.vigilantGuardian.bowed).toBe(false);
+                expect(this.player1).toHavePrompt('Action Window');
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/AncientStoneGuardian.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/AncientStoneGuardian.spec.js
@@ -1,0 +1,144 @@
+describe('Ancient Stone Guardian', function () {
+    integration(function () {
+        describe('Cannot be evaded', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['ikoma-ikehata']
+                    },
+                    player2: {
+                        inPlay: ['ancient-stone-guardian', 'shika-matchmaker'],
+                        provinces: ['shameful-display']
+                    }
+                });
+
+                this.ikehata = this.player1.findCardByName('ikoma-ikehata');
+
+                this.stoneGuardian = this.player2.findCardByName('ancient-stone-guardian');
+                this.matchmaker = this.player2.findCardByName('shika-matchmaker');
+                this.shamefulDisplay1 = this.player2.findCardByName('shameful-display', 'province 1');
+            });
+
+            it('should not be able to be evaded by covert', function () {
+                this.noMoreActions();
+                expect(this.player1).toHavePrompt('initiate conflict');
+                this.player1.clickCard(this.ikehata);
+                this.player1.clickRing('air');
+                this.player1.clickCard(this.shamefulDisplay1);
+
+                expect(this.player1).toHavePromptButton('Initiate Conflict');
+                this.player1.clickPrompt('Initiate Conflict');
+
+                expect(this.player1).toHavePrompt('Choose covert target for Ikoma Ikehata');
+                expect(this.stoneGuardian.covert).toBe(false);
+                this.player2.clickCard(this.stoneGuardian);
+                expect(this.player1).toHavePrompt('Choose covert target for Ikoma Ikehata');
+                expect(this.stoneGuardian.covert).toBe(false);
+                this.player1.clickPrompt('No Target');
+
+                expect(this.player2).toHavePrompt('Choose defenders');
+                this.player2.clickCard(this.stoneGuardian);
+                expect(this.stoneGuardian.isDefending()).toBe(true);
+                expect(this.ikehata.isAttacking()).toBe(true);
+            });
+        });
+
+        describe('Cannot participate as atacker', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['shinjo-archer', 'isawa-tadaka']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar', 'ancient-stone-guardian'],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.shinjoArcher = this.player1.findCardByName('shinjo-archer');
+                this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+
+                this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+                this.stoneGuardian = this.player2.findCardByName('ancient-stone-guardian');
+                this.assassination = this.player2.findCardByName('assassination');
+            });
+
+            it('should not be able to declare as an attacker ', function () {
+                this.noMoreActions();
+                this.player1.passConflict();
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    type: 'military',
+                    attackers: [this.stoneGuardian, this.solemnScholar],
+                    defenders: []
+                });
+                expect(this.game.currentConflict.attackers).toContain(this.solemnScholar);
+                expect(this.game.currentConflict.attackers).not.toContain(this.stoneGuardian);
+            });
+        });
+
+        describe('forced interrupt', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['shinjo-archer', 'isawa-tadaka']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar', 'ancient-stone-guardian'],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.shinjoArcher = this.player1.findCardByName('shinjo-archer');
+                this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+                this.isawaTadaka.dishonor();
+
+                this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+                this.stoneGuardian = this.player2.findCardByName('ancient-stone-guardian');
+                this.assassination = this.player2.findCardByName('assassination');
+            });
+
+            it('lets players dishonor characters to draw cards', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.shinjoArcher],
+                    defenders: [this.solemnScholar],
+                    type: 'military'
+                });
+
+                this.player2.clickCard(this.assassination);
+                this.player2.clickCard(this.stoneGuardian);
+
+                let p1HandSizeInit = this.player1.hand.length;
+                let p2HandSizeInit = this.player2.hand.length;
+
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toHavePromptButton('Done');
+                expect(this.player1).toBeAbleToSelect(this.shinjoArcher);
+                expect(this.player1).not.toBeAbleToSelect(this.isawaTadaka);
+
+                this.player1.clickCard(this.shinjoArcher);
+
+                expect(this.player2).toHavePrompt('Choose a character');
+                expect(this.player2).toHavePromptButton('Done');
+                expect(this.player2).toBeAbleToSelect(this.solemnScholar);
+                expect(this.player2).not.toBeAbleToSelect(this.stoneGuardian);
+
+                this.player2.clickPrompt('Done');
+
+                expect(this.shinjoArcher.isDishonored).toBe(true);
+                expect(this.player1.hand.length).toBe(p1HandSizeInit + 1);
+                expect(this.solemnScholar.isDishonored).toBe(false);
+                expect(this.player2.hand.length).toBe(p2HandSizeInit);
+
+                expect(this.getChatLogs(3)).toContain(
+                    'player2 uses Ancient Stone Guardian to present an opportunity to sneak around Ancient Stone Guardian and find some secrets! player1 dishonors Shinjo Archer to draw a card.'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/DisloyalOathkeeper.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/DisloyalOathkeeper.spec.js
@@ -1,0 +1,91 @@
+describe('Disloyal Oathkeeper', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-whisperer', 'isawa-tadaka'],
+                    hand: ['way-of-the-crane', 'against-the-waves', 'fine-katana', 'political-rival']
+                },
+                player2: {
+                    inPlay: ['disloyal-oathkeeper', 'doji-challenger'],
+                    hand: ['way-of-the-dragon', 'way-of-the-crane']
+                }
+            });
+
+            this.whisperer = this.player1.findCardByName('doji-whisperer');
+            this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+            this.crane = this.player1.findCardByName('way-of-the-crane');
+            this.waves = this.player1.findCardByName('against-the-waves');
+            this.katana = this.player1.findCardByName('fine-katana');
+            this.rival = this.player1.findCardByName('political-rival');
+
+            this.oathkeeper = this.player2.findCardByName('disloyal-oathkeeper');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.dragon = this.player2.findCardByName('way-of-the-dragon');
+            this.crane2 = this.player2.findCardByName('way-of-the-crane');
+
+            this.player1.pass();
+            this.player2.playAttachment(this.dragon, this.oathkeeper);
+        });
+
+        it('should react to an opponent\'s event and put it underneath self', function() {
+            this.player1.clickCard(this.crane);
+            this.player1.clickCard(this.whisperer);
+
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.oathkeeper);
+
+            this.player2.clickCard(this.oathkeeper);
+            expect(this.crane.location).toBe(this.oathkeeper.uuid);
+
+            expect(this.getChatLogs(5)).toContain('player2 uses Disloyal Oathkeeper to place Way of the Crane underneath Disloyal Oathkeeper');
+        });
+
+        it('event should be playable', function() {
+            this.player1.clickCard(this.crane);
+            this.player1.clickCard(this.whisperer);
+            this.player2.clickCard(this.oathkeeper);
+
+            this.player2.clickCard(this.crane);
+            this.player2.clickCard(this.challenger);
+            expect(this.challenger.isHonored).toBe(true);
+
+            expect(this.getChatLogs(5)).toContain('player2 plays Way of the Crane to honor Doji Challenger');
+        });
+
+        it('should not react if you already have a card underneath', function() {
+            this.player1.clickCard(this.crane);
+            this.player1.clickCard(this.whisperer);
+            this.player2.clickCard(this.oathkeeper);
+            expect(this.crane.location).toBe(this.oathkeeper.uuid);
+            this.player2.pass();
+
+            this.player1.clickCard(this.waves);
+            this.player1.clickCard(this.isawaTadaka);
+            expect(this.player2).toHavePrompt('Action Window');
+        });
+
+        it('should not react to an opponent\'s attachment', function() {
+            this.player1.clickCard(this.katana);
+            this.player1.clickCard(this.whisperer);
+
+            expect(this.player2).toHavePrompt('Action Window');
+        });
+
+        it('should not react to an opponent\'s character', function() {
+            this.player1.clickCard(this.rival);
+            this.player1.clickPrompt('0');
+
+            expect(this.player2).toHavePrompt('Action Window');
+        });
+
+        it('should not react to your own events', function() {
+            this.player1.pass();
+            this.player2.clickCard(this.crane2);
+            this.player2.clickCard(this.challenger);
+
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/IllusionaryDecoy.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/IllusionaryDecoy.spec.js
@@ -1,0 +1,199 @@
+describe('Illusionary Decoy', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['solemn-scholar', 'doji-challenger']
+                },
+                player2: {
+                    inPlay: ['doji-challenger', 'doji-whisperer'],
+                    hand: ['illusionary-decoy', 'isawa-tadaka-2']
+                }
+            });
+
+            this.decoy = this.player2.findCardByName('illusionary-decoy');
+            this.isawaTadaka = this.player2.findCardByName('isawa-tadaka-2');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.whisperer = this.player2.findCardByName('doji-whisperer');
+
+            this.solemnScholar = this.player1.findCardByName('solemn-scholar');
+            this.challenger1 = this.player1.findCardByName('doji-challenger');
+        });
+
+        it('should not be able to trigger action from hand', function () {
+            this.player1.pass();
+            expect(this.player2).toHavePrompt('Action Window');
+            this.player2.clickCard(this.decoy);
+            expect(this.player2).toHavePrompt('Action Window');
+        });
+
+        it('should not trigger when conflict begins unless the player controls a shugenja', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [this.challenger],
+                type: 'military'
+            });
+
+            expect(this.player2).not.toHavePrompt('Triggered Abilities');
+            expect(this.player2).not.toBeAbleToSelect(this.decoy);
+        });
+
+        it('should trigger when conflict begins', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.isawaTadaka);
+            this.player2.clickPrompt('0');
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [this.challenger],
+                type: 'military'
+            });
+
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.decoy);
+        });
+
+        it('enters play and can skip moving another character home', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.isawaTadaka);
+            this.player2.clickPrompt('0');
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [this.challenger],
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.decoy);
+            expect(this.player2).toHavePrompt('Select an action:');
+            expect(this.player2).toHavePromptButton('Move another of your characters home');
+            expect(this.player2).toHavePromptButton('Done');
+            this.player2.clickPrompt('Done');
+
+            expect(this.player2).not.toBeAbleToSelect(this.challenger);
+            expect(this.player2).not.toBeAbleToSelect(this.solemnScholar);
+            expect(this.player2).not.toBeAbleToSelect(this.whisperer);
+
+            expect(this.decoy.location).toBe('play area');
+            expect(this.decoy.isParticipating()).toBe(true);
+            expect(this.challenger.isParticipating()).toBe(true);
+            expect(this.getChatLogs(3)).toContain(
+                'player2 uses Illusionary Decoy to put Illusionary Decoy into play in the conflict'
+            );
+            expect(this.getChatLogs(3)).not.toContain(
+                'player2 moves home Doji Challenger - they were an Illusionary Decoy!'
+            );
+        });
+
+        it('enters play and can move another character home', function () {
+            this.player1.pass();
+            this.player2.clickCard(this.isawaTadaka);
+            this.player2.clickPrompt('0');
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [this.challenger],
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.decoy);
+            expect(this.player2).toHavePrompt('Select an action:');
+            expect(this.player2).toHavePromptButton('Move another of your characters home');
+            expect(this.player2).toHavePromptButton('Done');
+            this.player2.clickPrompt('Move another of your characters home');
+
+            expect(this.player2).toBeAbleToSelect(this.challenger);
+            expect(this.player2).not.toBeAbleToSelect(this.solemnScholar);
+            expect(this.player2).not.toBeAbleToSelect(this.whisperer);
+
+            this.player2.clickCard(this.challenger);
+
+            expect(this.decoy.location).toBe('play area');
+            expect(this.decoy.isParticipating()).toBe(true);
+            expect(this.challenger.isParticipating()).toBe(false);
+            expect(this.getChatLogs(3)).toContain(
+                'player2 uses Illusionary Decoy to put Illusionary Decoy into play in the conflict'
+            );
+            expect(this.getChatLogs(3)).toContain(
+                'player2 moves home Doji Challenger - they were an Illusionary Decoy!'
+            );
+        });
+
+        it('should return to hand with right conditions', function () {
+            this.player2.claimRing('earth');
+            this.player1.pass();
+            this.player2.clickCard(this.isawaTadaka);
+            this.player2.clickPrompt('0');
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.challenger1],
+                defenders: [this.challenger],
+                type: 'military',
+                ring: 'air'
+            });
+            this.player2.clickCard(this.decoy);
+            this.player2.clickPrompt('Done');
+            expect(this.decoy.location).toBe('play area');
+            expect(this.decoy.isParticipating()).toBe(true);
+
+            this.player2.clickCard(this.decoy);
+            expect(this.decoy.location).toBe('hand');
+            expect(this.getChatLogs(3)).toContain(
+                'player2 uses Illusionary Decoy to return Illusionary Decoy to their hand'
+            );
+        });
+
+        it('should not return to hand with wrong conditions', function () {
+            this.player2.claimRing('water');
+            this.player1.claimRing('earth');
+            this.player1.pass();
+            this.player2.clickCard(this.isawaTadaka);
+            this.player2.clickPrompt('0');
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.challenger1],
+                defenders: [this.challenger],
+                type: 'military',
+                ring: 'air'
+            });
+            this.player2.clickCard(this.decoy);
+            this.player2.clickPrompt('Done');
+            expect(this.decoy.location).toBe('play area');
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+            expect(this.decoy.isParticipating()).toBe(true);
+            this.player2.clickCard(this.decoy);
+            expect(this.decoy.location).toBe('play area');
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+        });
+
+        it('also returns to hand with same conditions, but outside conflicts', function () {
+            this.player2.claimRing('earth');
+            this.player1.pass();
+            this.player2.clickCard(this.isawaTadaka);
+            this.player2.clickPrompt('0');
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.challenger1],
+                defenders: [this.challenger],
+                type: 'military',
+                ring: 'air'
+            });
+            this.player2.clickCard(this.decoy);
+            this.player2.clickPrompt('Done');
+            expect(this.decoy.location).toBe('play area');
+            expect(this.decoy.isParticipating()).toBe(true);
+
+            this.player2.pass();
+            this.player1.pass();
+
+            this.player1.pass();
+            this.player2.clickCard(this.decoy);
+            expect(this.decoy.location).toBe('hand');
+            expect(this.getChatLogs(3)).toContain(
+                'player2 uses Illusionary Decoy to return Illusionary Decoy to their hand'
+            );
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/JadeColoredRocks.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/JadeColoredRocks.spec.js
@@ -1,0 +1,134 @@
+describe('Jade-Colored Rocks', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['isawa-tadaka'],
+                    hand: ['a-new-name']
+                },
+                player2: {
+                    provinces: ['jade-colored-rocks']
+                }
+            });
+
+            this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+            this.ann = this.player1.findCardByName('a-new-name');
+
+            this.jadeColoredRocks = this.player2.findCardByName('jade-colored-rocks', 'province 1');
+        });
+
+        it('should prompt owner to select 1 option', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.jadeColoredRocks,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.jadeColoredRocks);
+            expect(this.player2).toHavePrompt('Choose an option');
+            expect(this.player2.currentButtons).toContain('Opponent loses 1 fate');
+            expect(this.player2.currentButtons).toContain('Opponent loses 1 honor');
+            expect(this.player2.currentButtons).toContain('Opponent discards 1 card at random');
+        });
+
+        it('should be unable to trigger with no gamestate change', function() {
+            this.player1.fate = 0;
+            this.player1.moveCard(this.ann, 'conflict discard pile');
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.jadeColoredRocks,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.jadeColoredRocks);
+            expect(this.ann.location).toBe('conflict discard pile');
+            expect(this.player2).toHavePrompt('Choose an option');
+            expect(this.player2.currentButtons).not.toContain('Opponent loses 1 fate');
+            expect(this.player2.currentButtons).toContain('Opponent loses 1 honor');
+            expect(this.player2.currentButtons).not.toContain('Opponent discards 1 card at random');
+        });
+
+        it('should remove 1 fate', function() {
+            let initialFate = this.player1.fate;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.jadeColoredRocks,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.jadeColoredRocks);
+            this.player2.clickPrompt('Opponent loses 1 fate');
+            expect(this.player1.fate).toBe(initialFate - 1);
+        });
+
+        it('should remove 1 honor', function() {
+            let initialHonor = this.player1.honor;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.jadeColoredRocks,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.jadeColoredRocks);
+            this.player2.clickPrompt('Opponent loses 1 honor');
+            expect(this.player1.honor).toBe(initialHonor - 1);
+        });
+
+        it('should discard a card at random', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.jadeColoredRocks,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.jadeColoredRocks);
+            this.player2.clickPrompt('Opponent discards 1 card at random');
+            expect(this.ann.location).toBe('conflict discard pile');
+        });
+
+        it('should not remove 1 honor if at 6', function() {
+            this.player1.honor = 6;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.jadeColoredRocks,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.jadeColoredRocks);
+            expect(this.player2).toHavePrompt('Choose an option');
+            expect(this.player2.currentButtons).toContain('Opponent loses 1 fate');
+            expect(this.player2.currentButtons).not.toContain('Opponent loses 1 honor');
+            expect(this.player2.currentButtons).toContain('Opponent discards 1 card at random');
+        });
+
+        it('should not remove 1 honor if lower than 6', function() {
+            this.player1.honor = 2;
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.jadeColoredRocks,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.jadeColoredRocks);
+            expect(this.player2).toHavePrompt('Choose an option');
+            expect(this.player2.currentButtons).toContain('Opponent loses 1 fate');
+            expect(this.player2.currentButtons).not.toContain('Opponent loses 1 honor');
+            expect(this.player2.currentButtons).toContain('Opponent discards 1 card at random');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/KagiNawa.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/KagiNawa.spec.js
@@ -1,0 +1,82 @@
+describe('Kagi Nawa', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['shosuro-sadako', 'solemn-scholar', 'kitsu-motso'],
+                    hand: ['kagi-nawa']
+                },
+                player2: {
+                    inPlay: ['doji-challenger', 'alibi-artist', 'samurai-of-integrity']
+                }
+            });
+            this.sadako = this.player1.findCardByName('shosuro-sadako');
+            this.solemnScholar = this.player1.findCardByName('solemn-scholar');
+            this.kitsuMotso = this.player1.findCardByName('kitsu-motso');
+            this.kagiNawa = this.player1.findCardByName('kagi-nawa');
+
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.alibiArtist = this.player2.findCardByName('alibi-artist');
+            this.samuraiOfIntegrity = this.player2.findCardByName('samurai-of-integrity');
+        });
+
+        it('has no abilities when attached to a non-shinobi', function () {
+            this.player1.clickCard(this.kagiNawa);
+            this.player1.clickCard(this.solemnScholar);
+            expect(this.kagiNawa.location).toBe('play area');
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.solemnScholar],
+                defenders: [],
+                type: 'political'
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.solemnScholar);
+
+            expect(this.player1).not.toHavePrompt('Choose a character with printed cost 2 or lower to move in');
+        });
+
+        it('should not work outside a conflict', function () {
+            this.player1.clickCard(this.kagiNawa);
+            this.player1.clickCard(this.sadako);
+            this.player2.pass();
+            this.player1.clickCard(this.sadako);
+
+            expect(this.player1).toHavePrompt('Action Window');
+            expect(this.getChatLogs(3)).toContain('player1 plays Kagi-Nawa, attaching it to Shosuro Sadako');
+        });
+
+        it('should be able to select a 2 cost or lower character and move them to the conflict', function () {
+            this.player1.clickCard(this.kagiNawa);
+            this.player1.clickCard(this.sadako);
+            this.player1.clickCard(this.kagiNawa);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.sadako],
+                defenders: [],
+                type: 'political'
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.sadako);
+
+            expect(this.player1).toHavePrompt('Choose a character with printed cost 2 or lower to move in');
+            expect(this.player1).toBeAbleToSelect(this.solemnScholar);
+            expect(this.player1).toBeAbleToSelect(this.alibiArtist);
+            expect(this.player1).toBeAbleToSelect(this.samuraiOfIntegrity);
+            expect(this.player1).not.toBeAbleToSelect(this.sadako);
+            expect(this.player1).not.toBeAbleToSelect(this.kitsuMotso);
+            expect(this.player1).not.toBeAbleToSelect(this.challenger);
+
+            this.player1.clickCard(this.samuraiOfIntegrity);
+            expect(this.samuraiOfIntegrity.inConflict).toBe(true);
+            expect(this.getChatLogs(3)).toContain(
+                'player1 uses Shosuro Sadako\'s gained ability from Kagi-Nawa to hook Samurai of Integrity and drag them into the conflict'
+            );
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/SneakAttack.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/SneakAttack.spec.js
@@ -1,0 +1,102 @@
+describe('Sneak Attack', function () {
+    integration(function () {
+        describe('With a normal stronghold', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['bayushi-manipulator', 'shosuro-sadako'],
+                        hand: ['sneak-attack']
+                    },
+                    player2: {
+                        inPlay: ['wandering-ronin'],
+                        hand: ['for-shame', 'let-go']
+                    }
+                });
+
+                this.manipulator = this.player1.findCardByName('bayushi-manipulator');
+                this.sadako = this.player1.findCardByName('shosuro-sadako');
+                this.sneakAttack = this.player1.findCardByName('sneak-attack');
+
+                this.wanderingRonin = this.player2.findCardByName('wandering-ronin');
+                this.forShame = this.player2.findCardByName('for-shame');
+                this.letGo = this.player2.findCardByName('let-go');
+            });
+
+            it('should give the attacking player the first action opportunity and peak at opponent hand', function () {
+                let player1StartingHonor = this.player1.honor;
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.manipulator]
+                });
+
+                expect(this.player1).toHavePrompt('Waiting for opponent to choose defenders');
+                expect(this.player2).toHavePrompt('Choose defenders');
+
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickCard(this.sneakAttack);
+                expect(this.player1.honor).toBe(player1StartingHonor - 1);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+                expect(this.player2).toHavePrompt('Waiting for opponent to take an action or pass');
+
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 plays Sneak Attack, losing 1 honor to give player1 the first action in this conflict and peak at their opponent\'s hand'
+                );
+                expect(this.getChatLogs(5)).toContain('player1 sees For Shame! and Let Go in player2\'s hand');
+            });
+        });
+
+        describe('With Seven Stings Keep', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        stronghold: ['seven-stings-keep'],
+                        inPlay: ['bayushi-manipulator', 'shosuro-sadako'],
+                        hand: ['sneak-attack']
+                    },
+                    player2: {
+                        inPlay: ['wandering-ronin']
+                    }
+                });
+
+                this.keep = this.player1.findCardByName('seven-stings-keep');
+                this.manipulator = this.player1.findCardByName('bayushi-manipulator');
+                this.sadako = this.player1.findCardByName('shosuro-sadako');
+                this.sneakAttack = this.player1.findCardByName('sneak-attack');
+
+                this.wanderingRonin = this.player2.findCardByName('wandering-ronin');
+                this.shamefulDisplay = this.player2.findCardByName('shameful-display', 'province 1');
+            });
+
+            it('should give the attacking player the first action opportunity', function () {
+                let player1StartingHonor = this.player1.honor;
+                this.noMoreActions();
+
+                this.player1.clickCard(this.keep);
+                this.player1.clickPrompt('1');
+                expect(this.player1).toHavePrompt('Waiting for opponent to choose defenders');
+                expect(this.player2).toHavePrompt('Choose defenders');
+
+                this.player2.clickPrompt('Done');
+                expect(this.player1).toHavePrompt('Initiate Conflict');
+                expect(this.player1).not.toBeAbleToSelect(this.sneakAttack);
+
+                this.player1.clickCard(this.manipulator);
+                this.player1.clickRing('air');
+                this.player1.clickCard(this.shamefulDisplay);
+                this.player1.clickPrompt('Initiate Conflict');
+                expect(this.player1).toBeAbleToSelect(this.sneakAttack);
+
+                this.player1.clickCard(this.sneakAttack);
+                expect(this.player1.honor).toBe(player1StartingHonor - 1);
+                expect(this.player1).toHavePrompt('Conflict Action Window');
+                expect(this.player2).toHavePrompt('Waiting for opponent to take an action or pass');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 plays Sneak Attack, losing 1 honor to give player1 the first action in this conflict'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/UndergroundOphidiarium.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/UndergroundOphidiarium.spec.js
@@ -1,0 +1,61 @@
+describe('Underground Ophidiarium', function () {
+    integration(function () {
+        describe('Underground Ophidiarium\'s ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['wandering-ronin'],
+                        dynastyDiscard: ['underground-ophidiarium'],
+                        conflictDeck: [
+                            'fiery-madness',
+                            'backhanded-compliment',
+                            'kirei-ko'
+                        ]
+                    }
+                });
+
+                this.undergroundOphidiarium = this.player1.placeCardInProvince(
+                    'underground-ophidiarium',
+                    'province 1'
+                );
+            });
+
+            it('should prompt the player to choose a card', function () {
+                this.player1.clickCard(this.undergroundOphidiarium);
+                expect(this.player1).toHavePrompt('Underground Ophidiarium');
+            });
+
+            it('should prompt for only poison attachments', function () {
+                this.player1.clickCard(this.undergroundOphidiarium);
+                expect(this.player1).toHavePrompt('Select a card to reveal');
+                expect(this.player1).toHavePromptButton('Fiery Madness');
+                expect(this.player1).not.toHavePromptButton(
+                    'Backhanded Compliment'
+                );
+                expect(this.player1).not.toHavePromptButton('Kirei-ko');
+            });
+
+            it('should put the card in the player\'s hand', function () {
+                let handsize = this.player1.player.hand.size();
+                this.player1.clickCard(this.undergroundOphidiarium);
+                this.player1.clickPrompt('Fiery Madness');
+                expect(this.player1.player.hand.size()).toBe(handsize + 1);
+            });
+
+            it('should display message with chosen card name', function () {
+                this.player1.clickCard(this.undergroundOphidiarium);
+                this.player1.clickPrompt('Fiery Madness');
+                expect(this.getChatLogs(3)).toContain(
+                    'player1 uses Underground Ophidiarium, sacrificing Underground Ophidiarium to search conflict deck to reveal a poison attachment and add it to their hand'
+                );
+                expect(this.getChatLogs(2)).toContain(
+                    'player1 takes Fiery Madness'
+                );
+                expect(this.getChatLogs(1)).toContain(
+                    'player1 is shuffling their conflict deck'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Scorpion/ZealousInspector.spec.js
+++ b/test/server/cards/19.1-AS01/Scorpion/ZealousInspector.spec.js
@@ -1,0 +1,87 @@
+describe('Zealous Inspector', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['zealous-inspector', 'yogo-paramour'],
+                    hand: ['way-of-the-scorpion', 'ornate-fan']
+                },
+                player2: {
+                    inPlay: ['doji-challenger'],
+                    hand: ['spies-at-court', 'calling-in-favors']
+                }
+            });
+
+            this.inspector = this.player1.findCardByName('zealous-inspector');
+            this.paramour = this.player1.findCardByName('yogo-paramour');
+            this.ornateFan = this.player1.findCardByName('ornate-fan');
+            this.wayOfTheScorpion = this.player1.findCardByName(
+                'way-of-the-scorpion'
+            );
+
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.spies = this.player2.findCardByName('spies-at-court');
+            this.cif = this.player2.findCardByName('calling-in-favors');
+
+            // this.game.checkGameState(true);
+        });
+
+        it('triggers outside conflicts', function () {
+            this.player1.clickCard(this.paramour);
+            this.player1.clickCard(this.challenger);
+            expect(this.player1).toBeAbleToSelect(this.inspector);
+
+            this.player1.clickCard(this.inspector);
+            expect(this.player1).toHavePrompt('Initiate an action');
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Zealous Inspector to gain an additional action — time to deliver swift punishment for the wicked'
+            );
+        });
+
+        it('triggers during conflicts', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                ring: 'fire',
+                type: 'military',
+                attackers: [this.paramour, this.inspector],
+                defenders: [this.challenger]
+            });
+
+            this.player2.pass();
+
+            this.player1.clickCard(this.paramour);
+            this.player1.clickCard(this.challenger);
+            expect(this.player1).toBeAbleToSelect(this.inspector);
+
+            this.player1.clickCard(this.inspector);
+            expect(this.player1).toHavePrompt('Conflict Action Window');
+            expect(this.player2).toHavePrompt(
+                'Waiting for opponent to take an action or pass'
+            );
+
+            expect(this.getChatLogs(5)).toContain(
+                'player1 uses Zealous Inspector to gain an additional action — time to deliver swift punishment for the wicked'
+            );
+        });
+
+        it('Does not trigger during conflict resolutions due to ring effects', function () {
+            this.player1.clickCard(this.ornateFan);
+            this.player1.clickCard(this.inspector);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                ring: 'fire',
+                type: 'political',
+                attackers: [this.inspector],
+                defenders: [this.challenger]
+            });
+            this.noMoreActions();
+
+            this.player1.clickCard(this.challenger);
+            this.player1.clickPrompt('Dishonor Doji Challenger');
+
+            expect(this.player1).not.toBeAbleToSelect(this.inspector);
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/AshalanLantern.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/AshalanLantern.spec.js
@@ -1,0 +1,198 @@
+describe('Ashalan Lantern', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    fate: 3,
+                    inPlay: ['battle-maiden-recruit', 'saadiyah-al-mozedu'],
+                    hand: ['ashalan-lantern']
+                },
+                player2: {
+                    inPlay: ['brash-samurai', 'kakita-asami', 'courtly-challenger', 'tengu-sensei']
+                }
+            });
+
+            this.recruit = this.player1.findCardByName('battle-maiden-recruit');
+            this.saadiyah = this.player1.findCardByName('saadiyah-al-mozedu');
+            this.lantern = this.player1.findCardByName('ashalan-lantern');
+
+            this.brash = this.player2.findCardByName('brash-samurai');
+            this.asami = this.player2.findCardByName('kakita-asami');
+            this.courtly = this.player2.findCardByName('courtly-challenger');
+            this.tengu = this.player2.findCardByName('tengu-sensei');
+
+            this.player2.reduceDeckToNumber('dynasty deck', 0);
+        });
+
+        it('searches the top 3 dynasty cards for a character and play it, then discard attachment', function () {
+            this.player2.moveCard(this.brash, 'dynasty deck');
+            this.player2.moveCard(this.courtly, 'dynasty deck');
+            this.player2.moveCard(this.tengu, 'dynasty deck');
+
+            this.player1.clickCard(this.lantern);
+            this.player1.clickCard(this.recruit);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.recruit],
+                defenders: []
+            });
+
+            this.player2.pass();
+
+            let p1InitialFate = this.player1.fate;
+            this.player1.clickCard(this.lantern);
+
+            expect(this.player1).toHavePrompt('Name a card');
+            this.player1.chooseCardInPrompt('Good Omen', 'card-name');
+
+            expect(this.player1).toHavePrompt('Select a card to reveal');
+            expect(this.player1).toHavePromptButton(this.brash.name);
+            expect(this.player1).toHavePromptButton(this.courtly.name);
+            expect(this.player1).toHavePromptButton(this.tengu.name);
+
+            this.player1.clickPrompt(this.brash.name);
+            expect(this.player1).toHavePrompt('Choose additional fate');
+
+            this.player1.clickPrompt('0');
+            expect(this.brash.location).toBe('play area');
+            expect(this.game.currentConflict.attackers).toContain(this.brash);
+            expect(this.game.currentConflict.defenders).not.toContain(this.brash);
+            expect(this.player1.fate).toBe(p1InitialFate - 2);
+            expect(this.getChatLogs(10)).toContain(
+                'player1 uses Ashalan Lantern, naming Good Omen to look for a character on the top of player2\'s dynasty deck. They reveal Tengu Sensei, Courtly Challenger and Brash Samurai'
+            );
+            expect(this.getChatLogs(10)).toContain(
+                'Battle Maiden Recruit is not Foreign, their Ashalan Lantern is discarded'
+            );
+            expect(this.lantern.location).toBe('conflict discard pile');
+        });
+
+        it('searches the top 3 dynasty cards for a character and play it, then keep attachment if attached character is Foreign', function () {
+            this.player2.moveCard(this.brash, 'dynasty deck');
+            this.player2.moveCard(this.courtly, 'dynasty deck');
+            this.player2.moveCard(this.tengu, 'dynasty deck');
+
+            this.player1.clickCard(this.lantern);
+            this.player1.clickCard(this.saadiyah);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.saadiyah],
+                defenders: []
+            });
+
+            this.player2.pass();
+
+            let p1InitialFate = this.player1.fate;
+            this.player1.clickCard(this.lantern);
+
+            expect(this.player1).toHavePrompt('Name a card');
+            this.player1.chooseCardInPrompt('Good Omen', 'card-name');
+
+            expect(this.player1).toHavePrompt('Select a card to reveal');
+            expect(this.player1).toHavePromptButton(this.brash.name);
+            expect(this.player1).toHavePromptButton(this.courtly.name);
+            expect(this.player1).toHavePromptButton(this.tengu.name);
+
+            this.player1.clickPrompt(this.brash.name);
+            expect(this.player1).toHavePrompt('Choose additional fate');
+
+            this.player1.clickPrompt('0');
+            expect(this.brash.location).toBe('play area');
+            expect(this.game.currentConflict.attackers).toContain(this.brash);
+            expect(this.game.currentConflict.defenders).not.toContain(this.brash);
+            expect(this.player1.fate).toBe(p1InitialFate - 2);
+            expect(this.getChatLogs(10)).toContain(
+                'player1 uses Ashalan Lantern, naming Good Omen to look for a character on the top of player2\'s dynasty deck. They reveal Tengu Sensei, Courtly Challenger and Brash Samurai'
+            );
+            expect(this.getChatLogs(10)).toContain('player1 compels Brash Samurai into service');
+            expect(this.getChatLogs(10)).not.toContain(
+                'Saadiyah al-Mozedu is not Foreign, their Ashalan Lantern is discarded'
+            );
+            expect(this.lantern.location).toBe('play area');
+        });
+
+        it('gives 3 fate discount if character chosen matches the name', function () {
+            this.player2.moveCard(this.brash, 'dynasty deck');
+            this.player2.moveCard(this.courtly, 'dynasty deck');
+            this.player2.moveCard(this.tengu, 'dynasty deck');
+
+            this.player1.clickCard(this.lantern);
+            this.player1.clickCard(this.recruit);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.recruit],
+                defenders: []
+            });
+
+            this.player2.pass();
+
+            let p1InitialFate = this.player1.fate;
+            this.player1.clickCard(this.lantern);
+
+            expect(this.player1).toHavePrompt('Name a card');
+            this.player1.chooseCardInPrompt(this.tengu.name, 'card-name');
+
+            expect(this.player1).toHavePrompt('Select a card to reveal');
+            expect(this.player1).toHavePromptButton(this.brash.name);
+            expect(this.player1).toHavePromptButton(this.courtly.name);
+            expect(this.player1).toHavePromptButton(this.tengu.name);
+
+            this.player1.clickPrompt(this.tengu.name);
+            expect(this.player1).toHavePrompt('Choose additional fate');
+
+            this.player1.clickPrompt('0');
+            expect(this.tengu.location).toBe('play area');
+            expect(this.game.currentConflict.attackers).toContain(this.tengu);
+            expect(this.game.currentConflict.defenders).not.toContain(this.tengu);
+            expect(this.player1.fate).toBe(p1InitialFate - 2);
+            expect(this.getChatLogs(10)).toContain(
+                'player1 uses Ashalan Lantern, naming Tengu Sensei to look for a character on the top of player2\'s dynasty deck. They reveal Tengu Sensei, Courtly Challenger and Brash Samurai'
+            );
+            expect(this.getChatLogs(10)).toContain('player1 compels Tengu Sensei into service');
+            expect(this.getChatLogs(10)).toContain(
+                'player2 puts Courtly Challenger and Brash Samurai on the top of player1\' dynasty deck'
+            );
+            expect(this.getChatLogs(10)).toContain(
+                'Battle Maiden Recruit is not Foreign, their Ashalan Lantern is discarded'
+            );
+        });
+
+        it('allows to decide not play any character', function () {
+            this.player2.moveCard(this.brash, 'dynasty deck');
+            this.player2.moveCard(this.courtly, 'dynasty deck');
+            this.player2.moveCard(this.tengu, 'dynasty deck');
+
+            this.player1.clickCard(this.lantern);
+            this.player1.clickCard(this.recruit);
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.recruit],
+                defenders: []
+            });
+
+            this.player2.pass();
+
+            this.player1.clickCard(this.lantern);
+
+            expect(this.player1).toHavePrompt('Name a card');
+            this.player1.chooseCardInPrompt('Good Omen', 'card-name');
+
+            expect(this.player1).toHavePrompt('Select a card to reveal');
+            expect(this.player1).toHavePromptButton('Take nothing');
+
+            expect(this.getChatLogs(10)).toContain(
+                'player1 uses Ashalan Lantern, naming Good Omen to look for a character on the top of player2\'s dynasty deck. They reveal Tengu Sensei, Courtly Challenger and Brash Samurai'
+            );
+            this.player1.clickPrompt('Take nothing');
+            expect(this.lantern.location).toBe('play area');
+            expect(this.getChatLogs(10)).not.toContain(
+                'Battle Maiden Recruit is not Foreign, their Ashalan Lantern is discarded'
+            );
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/FieldsOfRollingThunder.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/FieldsOfRollingThunder.spec.js
@@ -1,0 +1,134 @@
+describe('Fields of Rolling Thunder', function () {
+    integration(function () {
+        describe('honoring ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['border-rider', 'doji-whisperer'],
+                        dynastyDiscard: ['fields-of-rolling-thunder']
+                    },
+                    player2: {
+                        inPlay: ['kaiu-siege-force']
+                    }
+                });
+
+                this.fields = this.player1.findCardByName('fields-of-rolling-thunder');
+                this.whisperer = this.player1.findCardByName('doji-whisperer');
+                this.rider = this.player1.findCardByName('border-rider');
+                this.player1.moveCard(this.fields, 'province 1');
+
+                this.siegeForce = this.player2.findCardByName('kaiu-siege-force');
+            });
+
+            it('honors a character and stays honored when winning the conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.rider, this.whisperer],
+                    defenders: [],
+                    type: 'military',
+                    ring: 'void'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.fields);
+                expect(this.player1).toBeAbleToSelect(this.rider);
+                expect(this.player1).not.toBeAbleToSelect(this.whisperer);
+
+                this.player1.clickCard(this.rider);
+                expect(this.rider.isHonored).toBe(true);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Fields of Rolling Thunder to honor Border Rider. They will be dishonored at the end of the conflict if player1 loses the conflict.'
+                );
+
+                this.noMoreActions();
+                this.player1.clickPrompt('Yes');
+
+                expect(this.rider.isHonored).toBe(true);
+            });
+
+            it('honors a character and dishonors them when losing the conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.rider, this.whisperer],
+                    defenders: [this.siegeForce],
+                    type: 'military',
+                    ring: 'void'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.fields);
+                expect(this.player1).toBeAbleToSelect(this.rider);
+                expect(this.player1).not.toBeAbleToSelect(this.whisperer);
+
+                this.player1.clickCard(this.rider);
+                expect(this.rider.isHonored).toBe(true);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Fields of Rolling Thunder to honor Border Rider. They will be dishonored at the end of the conflict if player1 loses the conflict.'
+                );
+
+                this.noMoreActions();
+
+                expect(this.rider.isHonored).toBe(false);
+            });
+        });
+
+        describe('unopposed reaction', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['solemn-scholar']
+                    },
+                    player2: {
+                        inPlay: [],
+                        dynastyDiscard: ['fields-of-rolling-thunder']
+                    }
+                });
+
+                this.solemn = this.player1.findCardByName('solemn-scholar');
+
+                this.fields = this.player2.findCardByName('fields-of-rolling-thunder');
+                this.player2.moveCard(this.fields, 'province 1');
+                this.fields.facedown = false;
+            });
+
+            it('discards itself after losing unopposed conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.solemn],
+                    defenders: [],
+                    type: 'political',
+                    ring: 'void'
+                });
+
+                expect(this.fields.location).toBe('province 1');
+
+                this.noMoreActions();
+                expect(this.fields.location).toBe('dynasty discard pile');
+                expect(this.getChatLogs(5)).toContain(
+                    'player2 uses Fields of Rolling Thunder to discard Fields of Rolling Thunder'
+                );
+            });
+
+            it('when facedown does not discards itself after losing unopposed conflict', function () {
+                this.fields.facedown = true;
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.solemn],
+                    defenders: [],
+                    type: 'political',
+                    ring: 'void'
+                });
+
+                expect(this.fields.location).toBe('province 1');
+                this.noMoreActions();
+
+                expect(this.fields.location).toBe('province 1');
+                expect(this.getChatLogs(5)).not.toContain(
+                    'player2 uses Fields of Rolling Thunder to discard Fields of Rolling Thunder'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/IchigoKun.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/IchigoKun.spec.js
@@ -1,0 +1,185 @@
+describe('Ichigo-kun', function () {
+    integration(function () {
+        describe('Ichigo-kun during fire conflicts', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['ichigo-kun', 'shika-matchmaker'],
+                        provinces: ['manicured-garden']
+                    },
+                    player2: {
+                        inPlay: ['ikoma-ikehata'],
+                        hand: ['elemental-inversion'],
+                        provinces: ['shameful-display']
+                    }
+                });
+
+                this.ichigoKun = this.player1.findCardByName('ichigo-kun');
+                this.matchmaker = this.player1.findCardByName('shika-matchmaker');
+                this.manicuredGarden = this.player1.findCardByName('manicured-garden', 'province 1');
+
+                this.shamefulDisplay1 = this.player2.findCardByName('shameful-display', 'province 1');
+                this.ikehata = this.player2.findCardByName('ikoma-ikehata');
+                this.elementalInversion = this.player2.findCardByName('elemental-inversion');
+            });
+
+            it('has zero base military during fire conflicts', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    ring: 'fire',
+                    type: 'military',
+                    attackers: [this.ichigoKun],
+                    defenders: []
+                });
+
+                expect(this.ichigoKun.getBaseMilitarySkill()).toBe(0);
+            });
+
+            it('has zero base military when the conflict element is changed to fire', function () {
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    ring: 'earth',
+                    type: 'military',
+                    attackers: [this.ichigoKun],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.elementalInversion);
+                this.player2.clickRing('fire');
+                expect(this.ichigoKun.getBaseMilitarySkill()).toBe(0);
+            });
+        });
+
+        describe('Ichigo-kun ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['ichigo-kun', 'worldly-shiotome']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar']
+                    }
+                });
+
+                this.ichigoKun = this.player1.findCardByName('ichigo-kun');
+                this.shiotome = this.player1.findCardByName('worldly-shiotome');
+
+                this.solemn = this.player2.findCardByName('solemn-scholar');
+                this.noMoreActions();
+            });
+
+            it('does not trigger when alone', function () {
+                this.initiateConflict({
+                    ring: 'void',
+                    type: 'military',
+                    attackers: [this.ichigoKun],
+                    defenders: [this.solemn]
+                });
+
+                this.player2.pass();
+
+                expect(this.player1).not.toHavePrompt('Triggered Abilities');
+                expect(this.player1).not.toBeAbleToSelect(this.ichigoKun);
+                expect(this.player1).not.toBeAbleToSelect(this.solemn);
+                expect(this.player1).not.toBeAbleToSelect(this.shiotome);
+            });
+
+            it('gains military on itself and reduces glory of companion', function () {
+                const ichigoInitialMil = this.ichigoKun.militarySkill;
+                const shiotomeInitialGlory = this.shiotome.glory;
+                this.initiateConflict({
+                    ring: 'void',
+                    type: 'military',
+                    attackers: [this.ichigoKun, this.shiotome],
+                    defenders: [this.solemn]
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.ichigoKun);
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).not.toBeAbleToSelect(this.ichigoKun);
+                expect(this.player1).not.toBeAbleToSelect(this.solemn);
+                expect(this.player1).toBeAbleToSelect(this.shiotome);
+
+                this.player1.clickCard(this.shiotome);
+                expect(this.player1).toHavePrompt('Select one');
+                expect(this.player1).toHavePromptButton('Increase own military, reduce other glory');
+                expect(this.player1).toHavePromptButton('Reduce own military, increase other glory');
+
+                this.player1.clickPrompt('Increase own military, reduce other glory');
+                expect(this.ichigoKun.militarySkill).toBe(ichigoInitialMil + 2);
+                expect(this.shiotome.glory).toBe(shiotomeInitialGlory - 2);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Ichigo-kun to give Ichigo-kun +2 military and Worldly Shiotome -2 glory - Ichigo-kun is wild today!'
+                );
+            });
+
+            it('loses military on itself and increases glory of companion', function () {
+                const ichigoInitialMil = this.ichigoKun.militarySkill;
+                const shiotomeInitialGlory = this.shiotome.glory;
+                this.initiateConflict({
+                    ring: 'void',
+                    type: 'military',
+                    attackers: [this.ichigoKun, this.shiotome],
+                    defenders: [this.solemn]
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.ichigoKun);
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).not.toBeAbleToSelect(this.ichigoKun);
+                expect(this.player1).not.toBeAbleToSelect(this.solemn);
+                expect(this.player1).toBeAbleToSelect(this.shiotome);
+
+                this.player1.clickCard(this.shiotome);
+                expect(this.player1).toHavePrompt('Select one');
+                expect(this.player1).toHavePromptButton('Increase own military, reduce other glory');
+                expect(this.player1).toHavePromptButton('Reduce own military, increase other glory');
+
+                this.player1.clickPrompt('Reduce own military, increase other glory');
+                expect(this.ichigoKun.militarySkill).toBe(ichigoInitialMil - 2);
+                expect(this.shiotome.glory).toBe(shiotomeInitialGlory + 2);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Ichigo-kun to give Ichigo-kun -2 military and Worldly Shiotome +2 glory - Ichigo-kun is well-behaved. Impressive!'
+                );
+            });
+
+            it('can move into the conflict with ability', function () {
+                const ichigoInitialMil = this.ichigoKun.militarySkill;
+                const shiotomeInitialGlory = this.shiotome.glory;
+                this.initiateConflict({
+                    ring: 'void',
+                    type: 'military',
+                    attackers: [this.shiotome],
+                    defenders: [this.solemn]
+                });
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.ichigoKun);
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).not.toBeAbleToSelect(this.ichigoKun);
+                expect(this.player1).not.toBeAbleToSelect(this.solemn);
+                expect(this.player1).toBeAbleToSelect(this.shiotome);
+
+                this.player1.clickCard(this.shiotome);
+                expect(this.player1).toHavePrompt('Select one');
+                expect(this.player1).toHavePromptButton('Increase own military, reduce other glory');
+                expect(this.player1).toHavePromptButton('Reduce own military, increase other glory');
+
+                this.player1.clickPrompt('Increase own military, reduce other glory');
+                expect(this.ichigoKun.militarySkill).toBe(ichigoInitialMil + 2);
+                expect(this.shiotome.glory).toBe(shiotomeInitialGlory - 2);
+                expect(this.ichigoKun.isParticipating()).toBe(true);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Ichigo-kun to give Ichigo-kun +2 military and Worldly Shiotome -2 glory - Ichigo-kun is wild today!'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/LongJourneyHome.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/LongJourneyHome.spec.js
@@ -1,0 +1,95 @@
+describe('Long Journey Home', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['moto-nergui'],
+                    hand: ['long-journey-home']
+                },
+                player2: {
+                    inPlay: ['doji-challenger','doji-whisperer'],
+                    hand: ['the-mountain-does-not-fall', 'ready-for-battle']
+                }
+            });
+            this.motoNergui = this.player1.findCardByName('moto-nergui');
+            this.longJourneyHome = this.player1.findCardByName('long-journey-home');
+
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.whisperer = this.player2.findCardByName('doji-whisperer');
+            this.mountain = this.player2.findCardByName('the-mountain-does-not-fall');
+            this.readyForBattle = this.player2.findCardByName('ready-for-battle');
+        });
+
+        it('should trigger on moving home by an effect and bow the character', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.motoNergui],
+                defenders: [this.challenger,this.whisperer],
+                type: 'military'
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.motoNergui);
+            this.player1.clickCard(this.challenger);
+
+            expect(this.challenger.location).toBe('play area');
+            expect(this.challenger.bowed).toBe(false);
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.longJourneyHome);
+
+            this.player1.clickCard(this.longJourneyHome);
+            expect(this.getChatLogs(3)).toContain(
+                'player1 plays Long Journey Home to make Doji Challenger take the long way home. Doji Challenger is bowed and cannot ready until the end of the phase'
+            );
+            expect(this.challenger.bowed).toBe(true);
+        });
+
+        it('should prevent the controller of affected character from readying it.', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.motoNergui],
+                defenders: [this.challenger,this.whisperer],
+                type: 'military'
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.motoNergui);
+            this.player1.clickCard(this.challenger);
+
+            this.player1.clickCard(this.longJourneyHome);
+            expect(this.challenger.bowed).toBe(true);
+            expect(this.player2).not.toHavePrompt('Triggered Abilities');
+            expect(this.player2).toHavePrompt('Conflict Action Window');
+        });
+
+        it('should trigger on moving home by the end of a conflict and bow the character', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.motoNergui],
+                defenders: [this.challenger, this.whisperer],
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.mountain);
+            this.player2.clickCard(this.challenger);
+            this.player1.pass();
+            this.player2.pass();
+
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.longJourneyHome);
+
+            this.player1.clickCard(this.longJourneyHome);
+            expect(this.player1).toBeAbleToSelect(this.challenger);
+            expect(this.player1).toBeAbleToSelect(this.whisperer);
+            expect(this.player1).not.toBeAbleToSelect(this.motoNergui);
+
+            this.player1.clickCard(this.challenger);
+            expect(this.getChatLogs(5)).toContain(
+                'player1 plays Long Journey Home to make Doji Challenger take the long way home. Doji Challenger is bowed and cannot ready until the end of the phase'
+            );
+            expect(this.challenger.location).toBe('play area');
+            expect(this.challenger.bowed).toBe(true);
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/ObsidianCaves.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/ObsidianCaves.spec.js
@@ -1,0 +1,100 @@
+describe('Obsidian Caves', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['isawa-tadaka', 'solemn-scholar'],
+                    hand: ['favored-mount'],
+                    dynastyDiscard: ['contested-countryside']
+                },
+                player2: {
+                    provinces: ['obsidian-caves'],
+                    inPlay: ['yasuki-taka']
+                }
+            });
+
+            this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+            this.solemnScholar = this.player1.findCardByName('solemn-scholar');
+            this.coco = this.player1.findCardByName('contested-countryside');
+            this.player1.placeCardInProvince(this.coco, 'province 1');
+            this.coco.facedown = false;
+            this.mount = this.player1.findCardByName('favored-mount');
+            this.player1.playAttachment(this.mount, this.isawaTadaka);
+
+            this.obsidianCaves = this.player2.findCardByName('obsidian-caves', 'province 1');
+            this.yasukiTaka = this.player2.findCardByName('yasuki-taka');
+        });
+
+        it('should allow choosing an attacking character', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [this.yasukiTaka],
+                province: this.obsidianCaves,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.obsidianCaves);
+            expect(this.player1).toHavePrompt('Choose a character to send home');
+            expect(this.player1).toBeAbleToSelect(this.isawaTadaka);
+            expect(this.player1).not.toBeAbleToSelect(this.solemnScholar);
+            expect(this.player1).not.toBeAbleToSelect(this.yasukiTaka);
+            this.player1.clickCard(this.isawaTadaka);
+            expect(this.isawaTadaka.inConflict).toBe(false);
+            expect(this.getChatLogs(3)).toContain('player2 uses Obsidian Caves to send Isawa Tadaka home');
+
+            this.player1.clickCard(this.mount);
+            this.player2.pass();
+
+            this.player1.clickCard(this.obsidianCaves);
+            expect(this.player1).toHavePrompt('Choose a character to send home');
+            expect(this.player1).toBeAbleToSelect(this.isawaTadaka);
+            expect(this.player1).not.toBeAbleToSelect(this.solemnScholar);
+            expect(this.player1).not.toBeAbleToSelect(this.yasukiTaka);
+
+            this.player1.clickCard(this.isawaTadaka);
+            expect(this.isawaTadaka.inConflict).toBe(false);
+            expect(this.getChatLogs(3)).toContain('player1 uses Obsidian Caves to send Isawa Tadaka home');
+        });
+
+        it('should allow the opponent to chose their participating character to send home and send it home', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [],
+                province: this.obsidianCaves,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.obsidianCaves);
+            expect(this.player1).toHavePrompt('Choose a character to send home');
+            expect(this.player1).toBeAbleToSelect(this.isawaTadaka);
+            expect(this.player1).not.toBeAbleToSelect(this.solemnScholar);
+
+            this.player1.clickCard(this.isawaTadaka);
+            expect(this.isawaTadaka.inConflict).toBe(false);
+            expect(this.getChatLogs(3)).toContain('player2 uses Obsidian Caves to send Isawa Tadaka home');
+        });
+
+        it('should allow the opponent to chose one of their participating character to send home and send it home', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka, this.solemnScholar],
+                defenders: [this.yasukiTaka],
+                province: this.obsidianCaves,
+                type: 'military'
+            });
+
+            this.player2.clickCard(this.obsidianCaves);
+            expect(this.player1).toHavePrompt('Choose a character to send home');
+            expect(this.player1).toBeAbleToSelect(this.isawaTadaka);
+            expect(this.player1).toBeAbleToSelect(this.solemnScholar);
+            expect(this.player1).not.toBeAbleToSelect(this.yasukiTaka);
+
+            this.player1.clickCard(this.solemnScholar);
+            expect(this.solemnScholar.inConflict).toBe(false);
+            expect(this.getChatLogs(3)).toContain('player2 uses Obsidian Caves to send Solemn Scholar home');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/Retribution.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/Retribution.spec.js
@@ -1,0 +1,266 @@
+describe('Retribution', function () {
+    integration(function () {
+        beforeEach(function () {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['doji-diplomat', 'shosuro-sadako', 'daidoji-kageyu'],
+                    hand: ['peacemaker-s-blade', 'pacifism']
+                },
+                player2: {
+                    inPlay: ['daidoji-uji', 'doji-challenger', 'adept-of-shadows', 'bayushi-liar', 'battle-maiden-recruit'],
+                    hand: ['retribution-']
+                }
+            });
+
+            this.sadako = this.player1.findCardByName('shosuro-sadako');
+            this.diplomat = this.player1.findCardByName('doji-diplomat');
+            this.kageyu = this.player1.findCardByName('daidoji-kageyu');
+            this.blade = this.player1.findCardByName('peacemaker-s-blade');
+            this.pacifism = this.player1.findCardByName('pacifism');
+
+            this.sd = this.player1.findCardByName('shameful-display', 'province 1');
+            this.sd2 = this.player1.findCardByName('shameful-display', 'province 2');
+
+            this.uji = this.player2.findCardByName('daidoji-uji');
+            this.challenger = this.player2.findCardByName('doji-challenger');
+            this.adept = this.player2.findCardByName('adept-of-shadows');
+            this.retribution = this.player2.findCardByName('retribution-');
+            this.liar = this.player2.findCardByName('bayushi-liar');
+            this.recruit = this.player2.findCardByName('battle-maiden-recruit');
+
+            this.uji.fate = 2;
+            this.uji.honor();
+            this.kageyu.honor();
+        });
+
+        it('should react if you lose a conflict, after resolution and let you pick an honored character or a battle maiden eligible to attack', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            expect(this.player1).toHavePrompt('Void ring');
+            this.player1.clickCard(this.uji);
+            expect(this.uji.fate).toBe(1);
+
+            expect(this.diplomat.bowed).toBe(true);
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.retribution);
+
+            this.player2.clickCard(this.retribution);
+            expect(this.player2).toBeAbleToSelect(this.uji);
+            expect(this.player2).toBeAbleToSelect(this.recruit);
+            expect(this.player2).not.toBeAbleToSelect(this.challenger);
+            expect(this.player2).not.toBeAbleToSelect(this.adept);
+            expect(this.player2).not.toBeAbleToSelect(this.diplomat);
+            expect(this.player2).not.toBeAbleToSelect(this.sadako);
+            expect(this.player2).not.toBeAbleToSelect(this.kageyu);
+        });
+
+        it('should let you pick an honored character eligible to attack (not eligible - bowed)', function () {
+            this.challenger.honor();
+            this.challenger.bow();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+            expect(this.player2).toBeAbleToSelect(this.retribution);
+
+            this.player2.clickCard(this.retribution);
+            expect(this.player2).toBeAbleToSelect(this.uji);
+            expect(this.player2).not.toBeAbleToSelect(this.challenger);
+        });
+
+        it('should let you pick an honored character eligible to attack (not eligible - cannot attack)', function () {
+            this.player1.playAttachment(this.blade, this.challenger);
+            this.challenger.honor();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+            expect(this.player2).toBeAbleToSelect(this.retribution);
+
+            this.player2.clickCard(this.retribution);
+            expect(this.player2).toBeAbleToSelect(this.uji);
+            expect(this.player2).not.toBeAbleToSelect(this.challenger);
+        });
+
+        it('should let you pick an honored character eligible to attack (not eligible - cannot participate)', function () {
+            this.player1.playAttachment(this.pacifism, this.challenger);
+            this.challenger.honor();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+            expect(this.player2).toBeAbleToSelect(this.retribution);
+
+            this.player2.clickCard(this.retribution);
+            expect(this.player2).toBeAbleToSelect(this.uji);
+            expect(this.player2).not.toBeAbleToSelect(this.challenger);
+        });
+
+        it('should let you pick an honored character eligible to attack (not eligible - dash mil)', function () {
+            this.liar.honor();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+            expect(this.player2).toBeAbleToSelect(this.retribution);
+
+            this.player2.clickCard(this.retribution);
+            expect(this.player2).toBeAbleToSelect(this.uji);
+            expect(this.player2).not.toBeAbleToSelect(this.liar);
+        });
+
+        it('should not react if you have no eligible characters', function () {
+            this.recruit.bow();
+            this.player1.playAttachment(this.pacifism, this.challenger);
+            this.player2.pass();
+            this.player1.playAttachment(this.blade, this.uji);
+            this.challenger.honor();
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+
+        it('should not react if you have fewer broken provinces', function () {
+            this.sd.isBroken = true;
+            this.sd2.isBroken = true;
+
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+
+            expect(this.player2).not.toHavePrompt('Triggered Abilities');
+            expect(this.player2).not.toBeAbleToSelect(this.retribution);
+        });
+
+        it('should immediately declare a conflict and force you to attack alone', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+            this.player2.clickCard(this.retribution);
+            this.player2.clickCard(this.uji);
+
+            expect(this.getChatLogs(10)).toContain('player2 plays Retribution! to declare a military conflict, attacking with Daidoji Uji');
+            expect(this.player2).toHavePrompt('Choose province to attack');
+            expect(this.player2).not.toHavePromptButton('Pass Conflict');
+
+            expect(this.player2.player.getConflictOpportunities()).toBe(3);
+            expect(this.player2.player.getRemainingConflictOpportunitiesForType('military')).toBe(2);
+
+            this.player2.clickRing('earth');
+            expect(this.game.rings['earth'].conflictType).toBe('military');
+            this.player2.clickRing('earth');
+            expect(this.game.rings['earth'].conflictType).toBe('military');
+
+            expect(this.game.currentConflict.attackers).toContain(this.uji);
+            this.player2.clickCard(this.uji);
+            expect(this.game.currentConflict.attackers).toContain(this.uji);
+            this.player2.clickCard(this.challenger);
+            expect(this.game.currentConflict.attackers).not.toContain(this.challenger);
+
+            this.player2.clickCard(this.sd);
+            this.player2.clickPrompt('Initiate Conflict');
+
+            this.player1.clickCard(this.kageyu);
+            expect(this.game.currentConflict.defenders).toContain(this.kageyu);
+            this.player1.clickCard(this.sadako);
+            expect(this.game.currentConflict.defenders).toContain(this.sadako);
+            this.player1.clickCard(this.diplomat);
+            expect(this.game.currentConflict.defenders).not.toContain(this.diplomat);
+
+            this.player1.clickPrompt('Done');
+        });
+
+        it('should not mess up conflict declaration on subsequent conflicts', function () {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.diplomat],
+                defenders: [],
+                type: 'political',
+                ring: 'void'
+            });
+
+            this.noMoreActions();
+            this.player1.clickCard(this.uji);
+            this.player2.clickCard(this.retribution);
+            this.player2.clickCard(this.uji);
+
+            this.player2.clickRing('earth');
+            this.player2.clickCard(this.sd);
+            this.player2.clickPrompt('Initiate Conflict');
+
+            this.player1.clickCard(this.kageyu);
+            this.player1.clickPrompt('Done');
+
+            this.uji.bow();
+            this.noMoreActions();
+
+            this.uji.ready();
+
+            this.noMoreActions(); // players2's conflict opportunity!  Back to back
+            this.initiateConflict({
+                attackers: [this.challenger, this.adept],
+                defenders: [],
+                type: 'military',
+                ring: 'air'
+            });
+
+            expect(this.game.currentConflict.attackers).not.toContain(this.uji);
+            expect(this.game.currentConflict.attackers).toContain(this.challenger);
+            expect(this.game.currentConflict.attackers).toContain(this.adept);
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/ShinjoArcher.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/ShinjoArcher.spec.js
@@ -1,0 +1,110 @@
+describe('Shinjo Archer', function() {
+    integration(function() {
+        beforeEach(function() {
+            this.setupTest({
+                phase: 'conflict',
+                player1: {
+                    inPlay: ['shinjo-archer', 'isawa-tadaka']
+                },
+                player2: {
+                    inPlay: ['solemn-scholar', 'kitsu-motso']
+                }
+            });
+
+            this.shinjoArcher = this.player1.findCardByName('shinjo-archer');
+            this.isawaTadaka = this.player1.findCardByName('isawa-tadaka');
+
+            this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+            this.kitsuMotso = this.player2.findCardByName('kitsu-motso');
+        });
+
+        it('should not work outside a conflict', function() {
+            expect(this.player1).toHavePrompt('Action Window');
+            this.player1.clickCard(this.shinjoArcher);
+            expect(this.player1).toHavePrompt('Action Window');
+        });
+
+        it('should be able to trigger in a conflict with another character and target participating characters', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.shinjoArcher],
+                defenders: [this.solemnScholar],
+                type: 'military'
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.shinjoArcher);
+            expect(this.player1).toHavePrompt('Choose a character');
+
+            expect(this.player1).toBeAbleToSelect(this.shinjoArcher);
+            expect(this.player1).toBeAbleToSelect(this.solemnScholar);
+            expect(this.player1).not.toBeAbleToSelect(this.isawaTadaka);
+            expect(this.player1).not.toBeAbleToSelect(this.kitsuMotso);
+        });
+
+        it('should be able to trigger in a conflict where it is not participating to target participating characters', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [this.solemnScholar],
+                type: 'military'
+            });
+
+            this.player2.pass();
+            this.player1.clickCard(this.shinjoArcher);
+            expect(this.player1).toHavePrompt('Choose a character');
+
+            expect(this.player1).not.toBeAbleToSelect(this.shinjoArcher);
+            expect(this.player1).toBeAbleToSelect(this.solemnScholar);
+            expect(this.player1).toBeAbleToSelect(this.isawaTadaka);
+            expect(this.player1).not.toBeAbleToSelect(this.kitsuMotso);
+        });
+
+        it('should send home Shinjo Archer and give the target -2/-2 unitl end of conflict', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.shinjoArcher],
+                defenders: [this.solemnScholar],
+                type: 'military'
+            });
+
+            expect(this.shinjoArcher.inConflict).toBe(true);
+            this.player2.pass();
+            this.player1.clickCard(this.shinjoArcher);
+            this.player1.clickCard(this.solemnScholar);
+
+            expect(this.shinjoArcher.inConflict).toBe(false);
+            expect(this.solemnScholar.getMilitarySkill()).toBe(0);
+            expect(this.solemnScholar.getPoliticalSkill()).toBe(0);
+
+            expect(this.getChatLogs(3)).toContain('player1 uses Shinjo Archer, moving Shinjo Archer home to give Solemn Scholar -2military/-2political');
+
+            this.player2.pass();
+            this.player1.pass();
+
+            expect(this.player1).toHavePrompt('Action Window');
+            expect(this.solemnScholar.getMilitarySkill()).toBe(1);
+            expect(this.solemnScholar.getPoliticalSkill()).toBe(1);
+        });
+
+        it('should move Shinjo Archer to the conflict and give the target -2/-2 unitl end of conflict', function() {
+            this.noMoreActions();
+            this.initiateConflict({
+                attackers: [this.isawaTadaka],
+                defenders: [this.solemnScholar],
+                type: 'military'
+            });
+
+            expect(this.shinjoArcher.inConflict).toBe(false);
+            this.player2.pass();
+            this.player1.clickCard(this.shinjoArcher);
+            this.player1.clickCard(this.solemnScholar);
+
+            expect(this.shinjoArcher.inConflict).toBe(true);
+            expect(this.solemnScholar.getMilitarySkill()).toBe(0);
+            expect(this.solemnScholar.getPoliticalSkill()).toBe(0);
+
+            expect(this.getChatLogs(3)).toContain('player1 uses Shinjo Archer, moving Shinjo Archer to the conflict to give Solemn Scholar -2military/-2political');
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/UtakuTakeko.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/UtakuTakeko.spec.js
@@ -1,0 +1,137 @@
+describe('Utaku Takeko', function () {
+    integration(function () {
+        describe('action ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        hand: ['assassination'],
+                        inPlay: ['utaku-takeko', 'moto-youth'],
+                        dynastyDiscard: [
+                            'border-rider',
+                            'moto-ariq',
+                            'akodo-toturi-2',
+                            'shinjo-yasamura',
+                            'moto-youth'
+                        ],
+                        conflictDiscard: ['shinjo-ambusher']
+                    },
+                    player2: {
+                        hand: ['assassination'],
+                        inPlay: ['border-rider'],
+                        dynastyDiscard: ['forthright-ide'],
+                        conflictDiscard: ['shiksha-scout']
+                    }
+                });
+
+                this.assassinationP1 = this.player1.findCardByName('assassination');
+                this.utakuTakeko = this.player1.findCardByName('utaku-takeko');
+                this.motoYouthStatingDiscarded = this.player1.filterCardsByName('moto-youth')[0];
+                this.motoYouthStartingInPlay = this.player1.filterCardsByName('moto-youth')[1];
+
+                this.discardBorderRider = this.player1.findCardByName('border-rider');
+                this.discardMotoAriq = this.player1.findCardByName('moto-ariq');
+                this.discardAkodoToturi = this.player1.findCardByName('akodo-toturi-2');
+                this.discardAmbusher = this.player1.findCardByName('shinjo-ambusher');
+                this.yasamura = this.player1.findCardByName('shinjo-yasamura');
+
+                this.discardForthrightIde = this.player2.findCardByName('forthright-ide');
+                this.discardShikshaScout = this.player2.findCardByName('shiksha-scout');
+                this.assassinationP2 = this.player2.findCardByName('assassination');
+                this.borderRiderP2 = this.player2.findCardByName('border-rider');
+            });
+
+            it('should allow you to pick a 1 glory or higher unicorn character from your dynasty discard pile and play it', function () {
+                this.player1.clickCard(this.utakuTakeko);
+
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.discardBorderRider); //Unicorn with 1 glory
+                expect(this.player1).not.toBeAbleToSelect(this.discardMotoAriq); //Unicorn with 0 glory
+                expect(this.player1).not.toBeAbleToSelect(this.discardAmbusher); //Unicorn with 1 glory but conflict discard
+                expect(this.player1).not.toBeAbleToSelect(this.discardAkodoToturi); // not a unicorn
+                expect(this.player1).not.toBeAbleToSelect(this.discardForthrightIde); // not in player discard pile
+                expect(this.player1).not.toBeAbleToSelect(this.discardShikshaScout); // not in player discard pile
+                expect(this.player1).not.toBeAbleToSelect(this.yasamura); // unicorn with 1 glory but unique
+
+                const initialPLayerFate = this.player1.fate;
+                this.player1.clickCard(this.discardBorderRider);
+                this.player1.clickPrompt('1');
+
+                expect(this.player1.fate).toBe(initialPLayerFate - 3); // 2 fate base + 1 extra fate placed
+                expect(this.discardBorderRider.location).toBe('play area');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Utaku Takeko to recall a distant relative who is a Border Rider'
+                );
+            });
+
+            it('should allow you to pick a 1 glory or higher unicorn character from your dynasty discard pile and play it at home during a conflict', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.utakuTakeko],
+                    defenders: [],
+                    type: 'political',
+                    ring: 'air'
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.utakuTakeko);
+
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.discardBorderRider); //Unicorn with 1 glory
+                expect(this.player1).not.toBeAbleToSelect(this.discardMotoAriq); //Unicorn with 0 glory
+                expect(this.player1).not.toBeAbleToSelect(this.discardAmbusher); //Unicorn with 1 glory but conflict discard
+                expect(this.player1).not.toBeAbleToSelect(this.discardAkodoToturi); // not a unicorn
+                expect(this.player1).not.toBeAbleToSelect(this.discardForthrightIde); // not in player discard pile
+                expect(this.player1).not.toBeAbleToSelect(this.discardShikshaScout); // not in player discard pile
+                expect(this.player1).not.toBeAbleToSelect(this.yasamura); // unicorn with 1 glory but unique
+
+                const initialPLayerFate = this.player1.fate;
+                this.player1.clickCard(this.discardBorderRider);
+                this.player1.clickPrompt('1');
+
+                expect(this.player1.fate).toBe(initialPLayerFate - 3); // 2 fate base + 1 extra fate placed
+                expect(this.discardBorderRider.location).toBe('play area');
+                expect(this.discardBorderRider.isParticipating()).toBe(false);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Utaku Takeko to recall a distant relative who is a Border Rider'
+                );
+            });
+
+            it('does not allow playing characters who were discarded in the same phase', function () {
+                this.noMoreActions();
+                this.initiateConflict({
+                    attackers: [this.utakuTakeko],
+                    defenders: [],
+                    type: 'political',
+                    ring: 'air'
+                });
+
+                this.player2.clickCard(this.assassinationP2);
+                this.player2.clickCard(this.motoYouthStartingInPlay);
+
+                this.player1.clickCard(this.assassinationP1);
+                this.player1.clickCard(this.borderRiderP2);
+
+                this.player2.pass();
+
+                this.player1.clickCard(this.utakuTakeko);
+
+                expect(this.player1).toHavePrompt('Choose a character');
+                expect(this.player1).toBeAbleToSelect(this.discardBorderRider); //Unicorn with 1 glory
+                expect(this.player1).not.toBeAbleToSelect(this.motoYouthStartingInPlay); // unicorn with 1 glory but just got discarded
+                expect(this.player1).not.toBeAbleToSelect(this.motoYouthStatingDiscarded); // unicorn with 1 glory but was already discarded
+
+                const initialPLayerFate = this.player1.fate;
+                this.player1.clickCard(this.discardBorderRider);
+                this.player1.clickPrompt('1');
+
+                expect(this.player1.fate).toBe(initialPLayerFate - 3); // 2 fate base + 1 extra fate placed
+                expect(this.discardBorderRider.location).toBe('play area');
+                expect(this.discardBorderRider.isParticipating()).toBe(false);
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Utaku Takeko to recall a distant relative who is a Border Rider'
+                );
+            });
+        });
+    });
+});

--- a/test/server/cards/19.1-AS01/Unicorn/WhispersOfTheLordsOfDeath.spec.js
+++ b/test/server/cards/19.1-AS01/Unicorn/WhispersOfTheLordsOfDeath.spec.js
@@ -1,0 +1,118 @@
+describe('Whispers of the Lords of Death', function () {
+    integration(function () {
+        describe('glory count effect', function () {
+            it('adds the highest MIL skill from each player to their count', function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['whispers-of-the-lords-of-death', 'moto-conqueror', 'aggressive-moto'],
+                        hand: ['curved-blade']
+                    },
+                    player2: {
+                        inPlay: ['repentant-legion', 'hida-kisada']
+                    }
+                });
+
+                this.curvedBlade = this.player1.findCardByName('curved-blade');
+                this.motoConqueror = this.player1.findCardByName('moto-conqueror');
+
+                this.player1.claimRing('earth');
+                this.player1.claimRing('water');
+                this.player2.claimRing('fire');
+                this.player2.claimRing('void');
+                this.player2.claimRing('air');
+
+                this.player1.clickCard(this.curvedBlade);
+                this.player1.clickCard(this.motoConqueror);
+
+                this.flow.finishConflictPhase();
+                /**
+                 * p1 =  7 = 2 rings + 0 Glory + 5 MIL
+                 * p2 = 13 = 3 rings + 1 Glory + 9 MIL
+                 */
+                expect(this.getChatLogs(5)).toContain('player2 wins the glory count 13 vs 7');
+            });
+        });
+
+        describe('put into play ability', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    phase: 'conflict',
+                    player1: {
+                        inPlay: ['iuchi-wayfinder', 'miya-mystic'],
+                        hand: ['whispers-of-the-lords-of-death', 'fine-katana']
+                    },
+                    player2: {
+                        inPlay: ['solemn-scholar'],
+                        hand: ['assassination']
+                    }
+                });
+
+                this.wayfinder = this.player1.findCardByName('iuchi-wayfinder');
+                this.mystic = this.player1.findCardByName('miya-mystic');
+                this.whispers = this.player1.findCardByName('whispers-of-the-lords-of-death');
+                this.katana = this.player1.findCardByName('fine-katana');
+
+                this.solemnScholar = this.player2.findCardByName('solemn-scholar');
+                this.assassination = this.player2.findCardByName('assassination');
+
+                this.player1.clickCard(this.katana);
+                this.player1.clickCard(this.wayfinder);
+            });
+
+            it('does not trigger outside conflicts', function () {
+                this.player1.clickCard(this.mystic);
+                this.player1.clickCard(this.katana);
+                expect(this.player1).not.toHavePrompt('Triggered Abilities');
+
+                this.player1.clickCard(this.whispers);
+                expect(this.whispers.location).toBe('hand');
+            });
+
+            it('trigger on own character leaving play due to own action', function () {
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    ring: 'earth',
+                    type: 'military',
+                    attackers: [this.wayfinder],
+                    defenders: []
+                });
+
+                this.player2.pass();
+                this.player1.clickCard(this.mystic);
+                this.player1.clickCard(this.katana);
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+
+                this.player1.clickCard(this.whispers);
+                expect(this.whispers.location).toBe('play area');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Whispers of the Lords of Death to put Whispers of the Lords of Death into play and claim the Imperial Favor'
+                );
+                expect(this.getChatLogs(5)).toContain('player1 claims the Emperor\'s military favor!');
+            });
+
+            it('trigger on own character leaving play due to opponent action', function () {
+                this.noMoreActions();
+
+                this.initiateConflict({
+                    ring: 'earth',
+                    type: 'military',
+                    attackers: [this.wayfinder],
+                    defenders: []
+                });
+
+                this.player2.clickCard(this.assassination);
+                this.player2.clickCard(this.wayfinder);
+                expect(this.player1).toHavePrompt('Triggered Abilities');
+
+                this.player1.clickCard(this.whispers);
+                expect(this.whispers.location).toBe('play area');
+                expect(this.getChatLogs(5)).toContain(
+                    'player1 uses Whispers of the Lords of Death to put Whispers of the Lords of Death into play and claim the Imperial Favor'
+                );
+                expect(this.getChatLogs(5)).toContain('player1 claims the Emperor\'s military favor!');
+            });
+        });
+    });
+});

--- a/test/server/integration/fatephase.spec.js
+++ b/test/server/integration/fatephase.spec.js
@@ -179,8 +179,16 @@ describe('(4) Fate Phase', function() {
                 expect(this.game.rings.water.fate).toBe(1);
             });
 
-            it('should raise an onPlaceFateOnUnclaimedRings event', function() {
-                expect(this.raiseEventSpy).toHaveBeenCalledWith('onPlaceFateOnUnclaimedRings', {}, jasmine.any(Function));
+            it('should raise an onPlaceFateOnUnclaimedRings event', function () {
+                expect(this.raiseEventSpy).toHaveBeenCalledWith(
+                    'onPlaceFateOnUnclaimedRings',
+                    jasmine.objectContaining({
+                        recipients: jasmine.arrayContaining([
+                            jasmine.objectContaining({ amount: 1, ring: jasmine.anything() })
+                        ])
+                    }),
+                    jasmine.any(Function)
+                );
             });
         });
 


### PR DESCRIPTION
* Add placeholders

* Include package-lock

* Oops

* Forest of Rustling Whispers

* Fortune's Field

* Cliffs of the Sea Dragon

* #27 Planted Fields

* #27 Added characters to tests

* #30 Protected Merchant

* The Empty City

* Cards!

* Daidoji Ahma

* Fix test spec  so it doesn't only run Empty City test anymore

* Shinjo Archer

* Cleanup Shinjo Archer

* Precocious Alchemist

* Cleanup Precocious Alchemist

* Otter Fisherman

* Obsidian Caves

* Mantis Raider

* Kaginawa

* Jade-Colored Rocks

* Yatakabune Port

* Cleanup Jade-Colored Rocks

* Cleanup

* Demon Bear

* Bloodthirsty Satsugai

* Bloodline of Benika

* Shore of the Ashen Flames

* Cleanup Shore of the Ashen Flames

* Ancient Golem

* Master of the Blade

* Cleanup

* Loyal Retainer (broken)

* Loyal Retainer

* Rest of the updates

* rename card id of Shore of the Ashen Flames

* Bug fixes

* PT updates 2022-09-28

* Added TST support for Firebrand

* Tooling for code style

* Mangrove Safehouse

* Underground Ophidiarium

* Eslint

* Correct spacing for effect text

* Test effect text for Mangrove Safehouse

* Eslint

* AS - Rustling Whispers

* Fields of Rolling Thunder

* Earnest Sculptor

* Broken Blades

* Update mangrove safehouse to new text

* Outmaneuvered by Force

* Forced Retirement

* Updated Cliffs of the Sea Dragon

* Palm Strike

* Seiji's Fate

* Kitsuki Seiji

* Nameless Brother

* Loyal Retainer

* Ancient Secrets: Lion cards

* Firebrand

* Gregarious Ward

* Paranoid Hososhi

* The Living Gate

* Vigilant Guardian

* Move Jade-Colored Rocks

* Update Kagi Nawa to only Shinobi you control

* Move Bloodthirsty Satsugai

* Sneak Attack

* Zealous Inspector

* Daidoji Ambusher

* Arrows from the woods

* Desperate Aide

* Developing Masterpiece and linting

* Fix corner the prey

* Ancient Secrets: Long Journey Home

* Ancient Secrets: Ichigo-Kun

* Ancient Secrets: Utaku Matriarch

* cleanup fdescribe

* Ancient Secrets: Kuro

* Ancient Secrets: Mantis Raider

* Ancient Secrets: Marvelous Beings

* Marvelous Beings cleanup

* Ancient Secrets: To Connect The People

* Fix bad test

* Fix targetting

* New Mantis Raider

* Eslint everything

* Ancient Secrets: To Govern the Land

* Ancient Secrets: To Show the Path

* The Lion's Shadow bugfix

* Ancient Secrets: To Sow the Earth

* Ancient Secrets: Writ of Sanctification

* Ancient Secrets: Writ of Survey

* Moving files around

* Moving files

* Added master of the blade and bamboo tattoo

* Shiba's Oath (#67)

* Kuni Aina (missing honor cost restriction) (#66)

* Fix: Make Fire element on Ichigo-kun changeable by TST (#68)

* Added Unicorn cards

* Tanuki

* Decoy

* Disloyal Oathkeeper & placeholder to play Jealous Ancestor as an attachment

* Updates

* Sneak attack

* Arrows from the Woods: Change reduction to be MilitarySkill only

* Fix circular dependency and a few tests

* Remove focus on test for Arrows from the Woods

* Update: Michievous Tanuki

* Update: To Sow The Earth

* Kuro: Check for attachable attachments.

* Ashalan Lantern

* Update: Mantis Raider

* Update: Mangrove Safehouse

* Update: Outmaneuvered by Force

* Update: Shore of Ashen Flames

* Update: Utaku Matriarch -> Utaku Takeko

* Update: Loyal Retainer -> Village Doshin

* Update: The Living Gate -> Servitor of Stone

* Update: Palm Strike

* Update: Master of the Blade

* Update: Palm Strike

* Update: Shiba's Oath

* Update: Paranoid Hososhi

* Update: The Empty City

* Update: Illusionary Decoy

* Update: Sneak Attack

* Update: Village Doshin

* Update: Relentless Gloryseeker

* Lords of Death

* Otter Fisherman: Fix so only Otter Fisherman controller may win the ring to trigger

* Utaku Takeko: fix put into play bug

Option to denote only into play at home for playcharacteractions

* fix lint

* Update: Ceremonial Robes

* Updated Ahma

* Update fisherman

* Updates 2023 02 03 (#72)

* Update: Mischievous Tanuki

* Update: Protected Merchant

* Lint

* adjust prettier to code style

* Update: To Connect the People

* Update: Storm from Sakkaku

* Update: Nature's Wrath

* Update: Storm from Sakkaku

* Update: protected Merchant

* Update: Retribution

* Update 2023 02 08 (#73)

* Update: Sneak Attack

* Update: Illusionary Decoy

* Update: Jealous Ancestor

* Update: Kuni Aina

* Update: The Empty City

* Update: Kitsuki Seiji

* Update 2023 02 10 (#74)

* Update: Cinder Salamander

* Update: Ichigo-kun

* Update: Ceremonial Robes

* Update 2023 02 15 (#75)

* Update: Kagi-nawa

* Update: Paranoid Hososhi

* Update: Mischievous Tanuki

* Update: Ceremonial Robes

* Update: Promising Hohei

* Update: Village Doshin

* Update: Forced Retirement

* Kuni Aina Shore of the Ashen Flames
Developing Masterpiece
To Show the Path

* Writ of Sanctification: Fix not targeting tainted characters with the ability.

* Writ of Survey: Fix falling off when parent is no longer honored

* Add guards to Palm Strike

* Update 2023 02 17 (#76)

* Update: Illusionary Decoy

* Update: Arrows from the Woods

* Update: Ceremonial Robes

* Update: rename Bloodline of Benika to Kinki

* Update: Rename Kuni Aina to Kuni Juurou

* Update: Rename Bloodthirsty Satsugai to Bloodthirsty Onryo

* Update: Fields of Rolling Thunder

* Update: Ashalan Lantern

* Update: To Govern the Land

* Update: Broken Blades

* Update: Mischievous Tanuki

* Update: Ceremonial Robes

* Update: Cliffs of the Sea Dragon

* Update: Ichigo-kun

* Update: The Lion's Shadow

* Update: Disable Master of the Blade

* Kitsuki Masanori

* Update 2023 03 02 (#77)

* Update: Broken Blades

* Update: Ancient Stone Guardian

* Update: Mangrove Safehouse

* Update: Seiji's Fate

* Update: Arrows from the Woods

* Update: Village Doshin

* Update: Fields of Rolling Thunder

* Update: Bamboo Tattoo

* Rename test

* Update: Whispers of the Lords of Death

* Update: Ichigo-kun

* Update 2023 03 09 (#78)

* Update: Shiba's Oath

* Update: Vigilant Guardian

* Update: Paranoid Hososhi

* Update: Seiji's Fate

* Update: Village Doshin

* Update: Bamboo Tatoo

* Update: Retribution

* Fluff: Utaku Takeko - update msg

* Update: Earnest Sculptor

* Update: Ashalan Lantern

* Fix: Ceremonial Robes counts glory only from characters in play

* Fix Ichigo-kun tests

* Update 2023 03 12 (#79)

* Update: Gregarious Ward

* Update: Daidoji Ambusher

* Update: Utaku Takeko

* Put the masterpieces into Masterpiece

* Update: Cinder Salamander

* Update: Retribution

* Update: Marvelous Beings

* Update: To Connect the People

* Update: Long Journey Home

* Fix: Ashalan Lantern

* Update: Ichigo-kun

* Update: Kitsuki Masanori

* NEW: Effect - playerFateCostToTargetCard

* Update: To Show the Path

* Fix: Allow Soldier tokens to be moved to hand

* Update: Promising Hohei test move soldier to hand

* Update: Developing Masterpiece

* Update: To Show the Path

* Update: Kitsuki Masanori

* Update: Utaku Takeko

---------